### PR TITLE
Set up contents of main branch

### DIFF
--- a/.github/workflows/gen-bundle-contents-when-nudged.yaml
+++ b/.github/workflows/gen-bundle-contents-when-nudged.yaml
@@ -1,0 +1,107 @@
+# Place a copy of this GitHub Actions workflow in the main and
+# each release branch of each bundle repo.
+
+name: Gen Bundle Contents When Nudged
+
+on:
+  workflow_dispatch: {}
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+    - backplane-*
+    paths:
+    - latest-snapshot.yaml
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # GitHub Actions automatically gives us a token with permissions to this reponsitory
+  # as determined by the permissive/restrictivve token-access setting for the repository.
+  # We should use this (and not override by setting GITHUB_TOKEN as a secret) for all
+  # access to this repository itself.
+  #
+  # Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+  #
+  # Save this token as REPO_GH_TOKEN in case we have to switch between using the
+  # repository token and other tokens with different permissions for other repositories.
+  #
+  # Despite the ref to secrets.GITHUB_TOKEN, DO NOT create a secret by that name!
+  # This secret is automatically provided.
+
+  GH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  process-nudge-pr:
+    runs-on: ubuntu-22.04
+    # FYI, the ubuntu-22.04 runner image includes Python 3.10
+
+    steps:
+    - name: Checkout triggered repo main branch
+
+      # Do sparse checkout  out the triggereed repo's main branch to get
+      # in-repo tools used by the workflow.
+
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        path: workflow
+        sparse-checkout: |
+          .github
+          config
+          tools
+        show-progress: false
+
+    - name: Generate GitHub token to read release tools repo
+
+      # The release-tools repo (stolostron/release, or a dev fork of it) is not
+      # currently public, and in some dev scenarios at least is not under the
+      # same org as the triggered rep and thus won't be in some of the workflow
+      # token we generate next.  So generate a token specifically for reading
+      # the release-tools repo.
+
+      id: gen-tools-repo-token
+      uses: actions/create-github-app-token@v1
+      with:
+        # App id and key of a GitHub App that has been installed and given
+        # read-only acccess to the contants ot the release-tools repo.
+        app-id: ${{ vars.TOOLS_REPO_READER_APP_ID }}
+        private-key: ${{ secrets.TOOLS_REPO_READER_PRIVATE_KEY }}
+        owner: ${{ vars.TOOLS_REPO_OWNER }}
+        repositories: "release"
+
+    - name: Generate GitHub token for workflow actions
+      id: gen-workflow-token
+      uses: actions/create-github-app-token@v1
+      with:
+        # App id and key of a GitHub App that has been installed and given access
+        # to the repos neded to do the core logic of the workflow.
+        app-id: ${{ vars.ACM_BUNDLE_BOT_APP_ID }}
+        private-key: ${{ secrets.ACM_BUNDLE_BOT_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Process nudge PR
+      env:
+        GH_CONTEXT: ${{ toJson(github) }}
+        GIT_USER:  ${{ vars.ACM_BUNDLE_BOT_GIT_USER }}
+
+        # Use the TOOLS_REPO_READER_TOKEN GitHub token when initially cloning
+        # the tools repo to obtain the common business logic there.
+        GH_TOOLS_REPO_READER_TOKEN: ${{ steps.gen-tools-repo-token.outputs.token }}
+
+        # Use the GH_WORKFLOW_TOKEN token witin workflow business logic.
+        GH_WORKFLOW_TOKEN: ${{ steps.gen-workflow-token.outputs.token }}
+
+      run: |
+        # Run the business-logic script
+
+        # Save GitHub context in env as compact JSON string rather than pretty-printed
+        export GH_CONTEXT=$(jq -c . <<< "$GH_CONTEXT")
+
+        # Use the workflow token by default.
+        export GITHUB_TOKEN="$GH_WORKFLOW_TOKEN"
+
+        # We start with current directoey being the top of the workflow repo clone
+        cd workflow
+        tools/run-script-from-tools-repo config/process-snapshot-pr-config-vars

--- a/config/process-snapshot-pr-config-vars
+++ b/config/process-snapshot-pr-config-vars
@@ -1,0 +1,15 @@
+# Common tools repo and the branch we clone:
+tools_repo=stolostron/release   # Assumed to be on GitHub.
+tools_repo_branch=master
+
+# Spot were we clone tools. (clone spot should NOT be under work_dir)
+tools_repo_clone_dir="./release-tools"
+
+# Pathname in release-tools repo of the script that is run by the
+# run-script-from-tools-repo front end.
+target_script=tools/konflux/bundle/process-snapshot-pr.sh
+
+# Pathnamein release branch of bundle repo  of the config file that
+# is used by $target_script
+target_script_config_file=config/mce-bundle-gen-config
+

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,15 @@
+Notes:
+
+The `run-script-from-tools-repo` script found in this directory is a front-end
+script that clones the release-tools repository and then invokes a target script
+from the cloned repository.  The repository and branch to clone and the pathame
+of the target script are set by configuration variables defined in a (sourced)
+Bash snippet that lives in the ocnfig directory of this branch.
+
+The front-end script is intended to be generic and version/release-depednency free so that
+the same code can be copied into the main branch of each bundle repository we will maintain
+for ACM and MCE, and hopefully there will be infrequent need to update those copies.
+If updates are needed, the master copy in the release-tools repo should be the spot
+that is first updated, and then manually propagated into each of the bundle repos.
+(There is no automatic sync mechanism in place.)
+

--- a/tools/run-script-from-tools-repo
+++ b/tools/run-script-from-tools-repo
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# This script is the front end to the Konflux generate-bundle-contents process for
+# ACM and related operator bundles.  It is invoked as the businss logic for GitHub
+# actions triggered on PRs, etc.  Its job is to determine and clone the common tooling
+# repo at the right branch, and then imvoke the appropriate bundle-contents-generation
+# core logic that lives in that tools repo (so that it can be common across all of
+# our operator-bundle repos and branches).
+#
+# Ideally, this script will contain nothing that is specific to the particular bundle
+# (i.e. ACM, or MCE, or Stolostron, etc.) that is being built.  All of the necessary
+# per-product particulars are obtained ehter by ssourcing script fragment files with
+# fixed names, or by referring environment varibales passed into the  script. The goal
+# is that it should be the cast that this script is identical across all of our various
+# bundle-building repos and branches in those repos. Maintaining this goal  will make
+# any required maintanance easy (just drop identical copies everywhere). And hopefully,
+# this script is a sufficently "thin" shim that the there will be minimal need to update
+# those identical copies, as the real" logic livs in the single, common tools repo.
+#
+# Inocation dependencies:
+#
+# This script assumes that when its run, the current working directory is the
+# top directory of the bundle-image repository.
+#
+# Note on dev testing:
+#
+# When doing development, its handy to have a working clone of the tools repo
+# that doesn't keep getting overridden by the "git clone" that would normally
+# be done by this script.  To request this, do:
+#
+# export dev_test_mode=1"
+#
+# before running this script. When this env var is set, this script only clones
+# the tools repo if not already present locally, and doesn't  get rid of it
+# in cleanup.
+#
+# Author: joeg-pro
+
+start_cwd="$PWD"
+
+# The config-vars sourceable script fragment sets some shell/environment variables
+# that we nedd to figure out how to clone the common tools and config repo and
+# run the business logic script contained there.
+
+in_repo_config_file="${1:-./config/config-vars}"
+if [[ ! -f "$in_repo_config_file" ]]; then
+  echo "ERROR: Required in-repo config file ($in_repo_config_file) not found."
+  exit 3
+fi
+source "$in_repo_config_file"
+
+# Make sure all of the vars we expect config-vars to set are in fact set.....
+
+if [[ -z "$tools_repo" ]] || [[ -z "$tools_repo_branch" ]]; then
+  echo "ERROR: Config variables tools_repo and/or tools_repo branch are not set."
+  exit 3
+fi
+
+if [[ -z "$tools_repo_clone_dir" ]]; then
+  echo "ERROR: Config variable tools_repo_clone_dir is not set."
+  exit 3
+fi
+
+if [[ -z "$target_script" ]]; then
+  echo "ERROR: Config variable target_script is not set."
+  exit 3
+fi
+
+# We need access to the tools repo, which may be private. In order to allow for
+#a least-priviledge granting of permissions f desired, we will prefer to use a
+# token specified in env var GH_TOOLS_REPO_READER_TOKEN so that a token that
+# provides only read-only access to the tools repo can be used while allowing
+# another tokens with more/different permisssion to be used by the target workflow
+# logic (GH_WORKFLOW_TOKEN). But for convenience, we'll fall back to using a
+# workflow-specific token from GH_WORKFLOW_TOKEN, or even a token found in the
+# commonly-defined GITHUB_TOKEN env var if nothing more specific is found.
+
+if [[ -n "$GH_TOOLS_REPO_READER_TOKEN" ]]; then
+   tools_repo_access_token="$GH_TOOLS_REPO_READER_TOKEN"
+   echo "Using GH_TOOLS_REPO_READER_TOKEN for access to tools repo."
+elif [[ -n "$GH_WORKFLOW_TOKEN" ]]; then
+   tools_repo_access_token="$GH_WORKFLOW_TOKEN"
+   echo "Using GH_WORKFLOW_TOKEN for access to tools repo."
+elif [[ -n "$GITHUB_TOKEN" ]]; then
+   tools_repo_access_token="$GITHUB_TOKEN"
+   echo "Using GITHUB_TOKEN for access to tools repo."
+else
+  echo "ERROR: None of GH_TOOLS_REPO_READER_TOKEN, GH_WORKFLOW_TOKEN or GITHUB_TOKEN is set."
+  exit 3
+fi
+
+# Get our tools and configs.
+
+if [[ $dev_test_mode -eq 0 ]]; then
+   rm -rf "$tools_repo_clone_dir"
+fi
+if [[ ! -d "$tools_repo_clone_dir" ]]; then
+   save_git_ssh_cmd=$(git config --global --get core.sshCommand)
+   git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+
+   # Optimized git clone logic that clones only the specified commit-SHA or branch names with
+   # no history as that is not useful to us. (Not possible with a direct "git clone" it seems.)
+   #
+   # Ref: https://stackoverflow.com/questions/31278902/how-to-shallow-clone-a-specific-commit-with-depth-1/43136160#43136160
+
+   mkdir -p "$tools_repo_clone_dir"
+   cd "$tools_repo_clone_dir"
+   tools_repo_clone_dir="$PWD"   # Ensuretools_repo_clone_dir an absolute pathname.
+   git config --global init.defaultBranch master
+   git config --global advice.detachedHead false
+   git init
+
+   # Rather than clone with an https URL that includes the token, instead clone
+   # generically and configure the git cline to add an Authenitcation header that
+   # specifies the endodedd "token:<TOKEN_VALUE>" auth info.
+
+   git remote add origin "https://github.com/$tools_repo"
+   basic_auth_creds="x-access-token:$tools_repo_access_token"
+   basic_auth_encoded=$(echo -n "$basic_auth_creds" | base64)
+   git config  "http.https://github.com/.extraheader" "Authorization: basic $basic_auth_encoded"
+
+   git fetch --depth 1 origin "$tools_repo_branch"
+   git_fetch_rc=$?
+
+   # In case we're run locally, be friendly and restore original Git SSH command
+   if [[ -n "$save_git_ssh_cmd" ]]; then
+      git config --global core.sshCommand "$save_git_ssh_cmd"
+   else
+      git config --global --unset core.sshCommand
+   fi
+   if [[ $git_fetch_rc -ne 0 ]]; then
+      echo "ERROR: Could not fetch tools repo."
+      exit 2
+  fi
+
+  git checkout FETCH_HEAD
+  git_checkout_rc=$?
+   if [[ $git_checkout_rc -ne 0 ]]; then
+      echo "ERROR: Could not checkout tools repo at FETCH_HEAD."
+      exit 2
+  fi
+else
+   echo "In dev-test mode, using already-cloned tools repo (at $tools_repo_clone_dir)."
+   cd "$tools_repo_clone_dir"
+   tools_repo_clone_dir="$PWD"   # Make tools_repo_clone_dir an absolute path
+fi
+
+cd "$start_cwd"
+
+# The actual work of the budnle generation process is hanled by a script (possibly common
+# across the various product bundles we produce) found in the tools repo. The name of that
+# script is provided by Variable target_script.
+
+target_script_path="$tools_repo_clone_dir/$target_script"
+if [[ ! -f "$target_script_path" ]]; then
+   echo "ERROR: Target script $target_script does not exist."
+   exit 2
+elif [[ ! -x "$target_script_path" ]]; then
+   echo "ERROR: Target script $target_script is not eecuable."
+   exit 2
+fi
+
+# Pass control to the core logic script.
+
+exec "$target_script_path" "$in_repo_config_file"
+# There is no return from this "exec", so cleanup and exit-code setting are up to the
+# tools-repo-resident logic we invoke. (Intentional, to keep this script as thin as possible.)


### PR DESCRIPTION
This PR adds the contents of the main branch of a bundle repo:
- A "placeholder" copy of the GitHib workflow for generating  bundle contents on "nudge" PRs, placed in this branch only because GitHub Actions seems to require a copy in the main branch.  But its the copies that will be placed into release branches that are actually used.
- A copy of the run-script-from-tools repo front end used by the workflows as they run in the context of the release branches
- A configuration file used by run-script-from-tools-repo.