### PR TITLE
Update backplane-2.7 branch per release-tools PR 667

### DIFF
--- a/.github/workflows/gen-bundle-contents-when-triggered.yaml
+++ b/.github/workflows/gen-bundle-contents-when-triggered.yaml
@@ -1,7 +1,7 @@
 # Place a copy of this GitHub Actions workflow in the main and
 # each release branch of each bundle repo.
 
-name: Gen Bundle Contents When Nudged
+name: Gen Bundle Contents When Triggered
 
 on:
   workflow_dispatch: {}
@@ -33,9 +33,9 @@ env:
   GH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  process-nudge-pr:
-    runs-on: ubuntu-22.04
-    # FYI, the ubuntu-22.04 runner image includes Python 3.10
+  process-triggering-pr:
+    runs-on: ubuntu-24.04
+    # FYI, the ubuntu-24.04 runner image includes Python 3.12
 
     steps:
     - name: Checkout triggered repo main branch
@@ -77,14 +77,14 @@ jobs:
       with:
         # App id and key of a GitHub App that has been installed and given access
         # to the repos neded to do the core logic of the workflow.
-        app-id: ${{ vars.ACM_BUNDLE_BOT_APP_ID }}
-        private-key: ${{ secrets.ACM_BUNDLE_BOT_PRIVATE_KEY }}
+        app-id: ${{ vars.WORKFLOW_BOT_APP_ID }}
+        private-key: ${{ secrets.WORKFLOW_BOT_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 
-    - name: Process nudge PR
+    - name: Process triggering PR
       env:
         GH_CONTEXT: ${{ toJson(github) }}
-        GIT_USER:  ${{ vars.ACM_BUNDLE_BOT_GIT_USER }}
+        GIT_USER:  ${{ vars.WORKFLOW_BOT_GIT_USER }}
 
         # Use the TOOLS_REPO_READER_TOKEN GitHub token when initially cloning
         # the tools repo to obtain the common business logic there.
@@ -104,4 +104,4 @@ jobs:
 
         # We start with current directoey being the top of the workflow repo clone
         cd workflow
-        tools/run-script-from-tools-repo config/process-snapshot-pr-config-vars
+        tools/run-script-from-tools-repo config/config-vars

--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -14,5 +14,6 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       io.openshift.tags="data,images" \
       io.k8s.display-name="multicluster-engine-operator-bundle" \
       maintainer="['acm-component-maintainers@redhat.com']" \
-      description="multicluster-engine-operator-bundle
+      description="multicluster-engine-operator-bundle" \
+      konflux.additional-tags="vBUNDLE_VERSION"
 

--- a/config/mce-bundle-gen-config
+++ b/config/mce-bundle-gen-config
@@ -15,9 +15,9 @@ ocp_versions="v4.12-v4.18"
 # PAthnames of the scripts used to generate the unbound and unbound bundle manifests
 # for this product, and the config file the scripts need.
 
-unbound_bundle_manifests_gen_script="tools/bundle-manifests-gen/gen-unbound-mce-bundle.sh"
-bound_bundle_manifests_gen_script="tools/bundle-manifests-gen/gen-bound-mce-bundle.sh"
-bundle_manifests_gen_config_file="tools/bundle-manifests-gen/mce-bundle.config"
+unbound_bundle_manifests_gen_script="tools/konflux/bundle/gen-unbound-mce-bundle.sh"
+bound_bundle_manifests_gen_script="tools/konflux/bundle/gen-bound-mce-bundle.sh"
+bundle_manifests_gen_config_file="tools/konflux/bundle/mce-bundle.config"
 
 # Pathname of the config file for the image manifest generation script
 # Note: This is relative to the top of the bundle repo (release branch).
@@ -28,9 +28,6 @@ add_iteration_suffix=1
 #----------------------------------------------------
 # Config properties likely the same for all products
 #----------------------------------------------------
-
-# Pathname of the script that has the core business logic to generate bundle contents.
-bundle_contents_gen_script=tools/konflux/bundle/generate-bundle-contents.sh
 
 # Pathname of the script that generates the image manifest.
 image_manifest_gen_script="tools/konflux/bundle/generate_konflux_manifest.py"


### PR DESCRIPTION
This PR picks up the changes needed in the `backplane-2.7`  branch of this bundle repo required by the tooling changes made by https://github.com/stolostron/release/pull/667.

(This is a cherry pick of PR #11 that made these changes in the `release-branch-template` branch.)
