### PR TITLE
Update backplane-2.7 branch config per release-tools PRs 670-671

### DIFF
--- a/.github/workflows/gen-bundle-contents-when-triggered.yaml
+++ b/.github/workflows/gen-bundle-contents-when-triggered.yaml
@@ -94,6 +94,13 @@ jobs:
         GH_WORKFLOW_TOKEN: ${{ steps.gen-workflow-token.outputs.token }}
 
       run: |
+        # Authenticate to needed image registries...
+
+        # Access to registry.redhat.io needed to resolve external image references:
+        echo "Doing Docker login to registry.redhat.io"
+        echo "${{ secrets.REGISTRY_REDHAT_IO_RGY_PASSWORD }}" \
+           | docker login -u="${{ vars.REGISTRY_REDHAT_IO_RGY_USERNAME }}" --password-stdin registry.redhat.io
+
         # Run the business-logic script
 
         # Save GitHub context in env as compact JSON string rather than pretty-printed

--- a/config/mce-bundle-gen-config
+++ b/config/mce-bundle-gen-config
@@ -1,34 +1,68 @@
+# This Bash fragment is sourced by various scripts.
+#
+# Its job is to set a bunch of configuration variable as expected by the
+# bundle manifest generation scripts that source it.  Because it is Bash, you
+# can use any Bash constructs you want here, but be careful  about setting
+# variables that might break the sourcing script.
 
-# Note: Except where noted differently, all pathnames defined in config
-# vars are relative to the top of this Git repo.
+#--------------------------------------------------------------------
+# Config properties that are unique for each prodct (ACM vs. MCE)
+# and often/ocasionally differ release-to-release.
+#
+# Be sure to consider these settings in release-to-release cutovers.
+#--------------------------------------------------------------------
 
-#--------------------------------------------------
-# Config properties likely unique for this product
-#--------------------------------------------------
+# List or range of COP versions to which bundles should be published.
+# Note: This variable is used/effective only for CPASS builds.  For Konflux
+# builds, this range is now set in configuration files for the catalog
+# generation steps.
 
-# Name of the OLM operator package
-olm_package="multicluster-engine"
-
-# List or range of COP versions this operator package should be published to:
 ocp_versions="v4.12-v4.18"
 
-# PAthnames of the scripts used to generate the unbound and unbound bundle manifests
-# for this product, and the config file the scripts need.
+# When non-zero, a build-number/iteration suffix is added to CSV/bundle versions
+add_iteration_suffix=1
+
+# Specify the list of arechitectures and operating systems we support.
+
+# Since MCE 2.0:
+cfg_supported_op_syss=("linux")
+cfg_supported_archs=("amd64", "ppc64le" "s390x" "arm64")
+
+# Specify EUS-release configuration:
+
+cfg_first_eus_release_xy=2.6
+cfg_eus_release_cadence=2
+
+#-----------------------------------------------------------------
+# Config properties that are unique for each prodct (ACM vs. MCE)
+# but usually constant across releases of the product.
+#-----------------------------------------------------------------
+
+# Name of the OLM operator package:
+
+cfg_pkg_name="multicluster-engine"
+cfg_short_display_name="MCE"
+olm_package="$cfg_pkg_name"   # Alternate name for this config variable
+
+# Name of the CSV template file.  This file is assumed to live in the
+# tools repo in the same directory as $unbound_bundle_manifests_gen_script.
+cfg_csv_template="mce-csv-template.yaml"
+
+# Pathnames (in tools repo) of the scripts used to generate the unbound
+# and bound bundle manifests for this product.
 
 unbound_bundle_manifests_gen_script="tools/konflux/bundle/gen-unbound-mce-bundle.sh"
 bound_bundle_manifests_gen_script="tools/konflux/bundle/gen-bound-mce-bundle.sh"
-bundle_manifests_gen_config_file="tools/konflux/bundle/mce-bundle.config"
 
-# Pathname of the config file for the image manifest generation script
+# Pathname (in bundle repo) of the config file for the image manifest generation
+# script referenced by $image_manifest_gen_script
 # Note: This is relative to the top of the bundle repo (release branch).
 image_manifest_gen_config_file="config/mce-manifest-gen-config.json"
-
-add_iteration_suffix=1
 
 #----------------------------------------------------
 # Config properties likely the same for all products
 #----------------------------------------------------
 
-# Pathname of the script that generates the image manifest.
+# Pathname (in tools repo) of the script that generates the image manifest.
 image_manifest_gen_script="tools/konflux/bundle/generate_konflux_manifest.py"
 


### PR DESCRIPTION
This PR picks up the config changes needed in the `backplane-2.7` branch of this bundle repo as required by the tooling changes made by https://github.com/stolostron/release/pull/670 and https://github.com/stolostron/release/pull/671.