### PR TITLE
Temporaroly use acm-d image refs so they resolve

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -39,31 +39,31 @@
         "image-list": [
             {
               "image-key":      "assisted_image_service",
-              "note-image-tag": "v2.8.0-12",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-image-service-rhel9@sha256:e9a82706babe1ee0b8a691f1baf33e3835196a93dc7bf750d01603c50783b97e"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-image-service-rhel9:v2.8.0-13"
             },{
               "image-key":      "assisted_installer",
-              "note-image-tag": "v2.8.0-14",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-installer-rhel9@sha256:25d4538a3d1b1ebd69aea797ba1cd81d7c723301a11117d11af3b88b3ae88a12"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-installer-rhel9:v2.8.0-15"
             },{
               "image-key":      "assisted_installer_agent",
-              "note-image-tag": "v2.8.0-12",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9@sha256:f0b6025ead181a1167bafb692055e858a4f550927eeb3549d29a5b5f33cbc42a"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-installer-agent-rhel9:v2.8.0-13"
             },{
               "image-key":      "assisted_installer_controller",
-              "note-image-tag": "v2.8.0-13",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-installer-controller-rhel9@sha256:04bd9de7f11088df08dd8d497944fbd2cac7eba9971a932ca8dde7f3a2f1449e"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-installer-controller-rhel9:v2.8.0-14"
             },{
               "image-key":      "assisted_service_8",
-              "note-image-tag": "v2.8.0-23",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-service-8-rhel8@sha256:2421ebb82f0f9c873a3c4b5c9a3512b305af0bc49b654fd9cfe077c51dfdd873"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-service-8-rhel8:v2.8.0-24"
             },{
               "image-key":      "assisted_service_9",
-              "note-image-tag": "v2.8.0-23",
-              "image-ref":      "registry.redhat.io/multicluster-engine/assisted-service-9-rhel9@sha256:49bbd93906456948a60c6e5eab8de452bc5884dcfe04eacad61fcaec3cef37c7"
+              "note-1":         "This is a placeholder image reference",
+              "image-ref":      "quay.io/acm-d/assisted-service-9-rhel9:v2.8.0-24"
             },{
-              "image-key":       "postgresql_12",
-              "image-ref":       "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"
+              "image-key":      "postgresql_12",
+              "image-ref":      "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"
             }
         ]
     }


### PR DESCRIPTION
We probably need to revisit how we're going to handle/configure external image entries for not-yet-published (shipped) images.  As temporary scaffolding, change the image refs for AI things to point to quay.io/acm-d so they resolve even though that will causes these quay.io/acm-d refs to appear in the bundle.