### PR TITLE
Update Dockerfile template to add snapshot-name tag

### DIFF
--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -15,5 +15,5 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       io.k8s.display-name="multicluster-engine-operator-bundle" \
       maintainer="['acm-component-maintainers@redhat.com']" \
       description="multicluster-engine-operator-bundle" \
-      konflux.additional-tags="v${BUNDLE_VERSION}"
+      konflux.additional-tags="v${BUNDLE_VERSION},shapshot-${SNAPSHOT_NAME}"
 


### PR DESCRIPTION
Per release-tools PR stolostron/release#709, this PR updates the bundle Dockerfile template to add a  snapshot-name-based tag to the `konflux.additional-tags` list.