### PR TITLE
Update gen-latest-snapshot.yaml

### DIFF
--- a/.github/workflows/gen-latest-snapshot.yaml
+++ b/.github/workflows/gen-latest-snapshot.yaml
@@ -16,9 +16,9 @@ jobs:
           branch: ['backplane-2.7']
           include:
             - branch: backplane-2.7
-              release-plan: "publish-dev-mce-27"
+              release-plan: "dev-publish-mce-27"
             - branch: backplane-2.9
-              release-plan: "publish-dev-mce-29"
+              release-plan: "dev-publish-mce-29"
 
     steps:
       - name: Checkout tooling branch


### PR DESCRIPTION
This should extend the tooling to work with mce 2.9 releaseplan