### PR TITLE
Remove invalid comma from arch list

### DIFF
--- a/config/mce-bundle-gen-config
+++ b/config/mce-bundle-gen-config
@@ -28,7 +28,7 @@ add_iteration_suffix=1
 
 # Since MCE 2.0:
 cfg_supported_op_syss=("linux")
-cfg_supported_archs=("amd64", "ppc64le" "s390x" "arm64")
+cfg_supported_archs=("amd64" "ppc64le" "s390x" "arm64")
 
 # Specify EUS-release configuration:
 

--- a/manifests/multicluster-engine.v2.9.0-11.clusterserviceversion.yaml
+++ b/manifests/multicluster-engine.v2.9.0-11.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
   name: multicluster-engine.v2.9.0-11
   namespace: placeholder
   labels:
-    operatorframework.io/arch.amd64,: supported
+    operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.arm64: supported


### PR DESCRIPTION
Install failure due to invalid command in the csv labels