### PR TITLE
Fix bad image references in our new mapping to acm-d

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -11,23 +11,22 @@
             {"image-key": "cluster_api",                      "konflux-component-name": "cluster-api", "publish-name": "cluster-api-rhel9"},
             {"image-key": "cluster_api_provider_agent",       "konflux-component-name": "cluster-api-provider-agent", "publish-name": "cluster-api-provider-agent-rhel9"},
             {"image-key": "cluster_api_provider_kubevirt",    "konflux-component-name": "cluster-api-provider-kubevirt", "publish-name": "cluster-api-provider-kubevirt-rhel9"},
-            {"image-key": "clusterclaims_controller",         "konflux-component-name": "clusterclaims-controller", "publish-name": "clusterclaims-controller"},
-            {"image-key": "cluster_curator_controller",       "konflux-component-name": "cluster-curator-controller", "publish-name": "cluster-curator-controller"},
-            {"image-key": "cluster_image_set_controller",     "konflux-component-name": "cluster-image-set-controller", "publish-name": "cluster-image-set-controller"},
+            {"image-key": "clusterclaims_controller",         "konflux-component-name": "clusterclaims-controller", "publish-name": "clusterclaims-controller-rhel9"},
+            {"image-key": "cluster_curator_controller",       "konflux-component-name": "cluster-curator-controller", "publish-name": "cluster-curator-controller-rhel9"},
+            {"image-key": "cluster_image_set_controller",     "konflux-component-name": "cluster-image-set-controller", "publish-name": "cluster-image-set-controller-rhel9"},
             {"image-key": "clusterlifecycle_state_metrics",   "konflux-component-name": "clusterlifecycle-state-metrics", "publish-name": "clusterlifecycle-state-metrics-rhel9"},
             {"image-key": "cluster_proxy_addon",              "konflux-component-name": "cluster-proxy-addon", "publish-name": "cluster-proxy-addon-rhel9"},
             {"image-key": "cluster_proxy",                    "konflux-component-name": "cluster-proxy", "publish-name": "cluster-proxy-rhel9"},
             {"image-key": "console_mce",                      "konflux-component-name": "console-mce", "publish-name": "console-mce-rhel9"},
-            {"image-key": "discovery_operator",               "konflux-component-name": "discovery-operator", "publish-name": "discovery-operator-rhel9"},
-            {"image-key": "hypershift_addon_operator",        "konflux-component-name": "hypershift-addon-operator", "publish-name": "hypershift-addon-operator-rhel9"},
+            {"image-key": "discovery_operator",               "konflux-component-name": "discovery-operator", "publish-name": "discovery-rhel9"},
+            {"image-key": "hypershift_addon_operator",        "konflux-component-name": "hypershift-addon-operator", "publish-name": "hypershift-addon-rhel9-operator"},
             {"image-key": "hypershift_cli",                   "konflux-component-name": "hypershift-cli", "publish-name": "hypershift-cli-rhel9"},
             {"image-key": "hypershift_operator",              "konflux-component-name": "hypershift-release", "publish-name": "hypershift-rhel9-operator"},
-            {"image-key": "image_based_install_operator",     "konflux-component-name": "image-based-install-operator", "publish-name": "image-based-install-operator-rhel9"},
+            {"image-key": "image_based_install_operator",     "konflux-component-name": "image-based-install-operator", "publish-name": "image-based-install-rhel9"},
             {"image-key": "kube_rbac_proxy_mce",              "konflux-component-name": "kube-rbac-proxy", "publish-name": "kube-rbac-proxy-rhel9"},
-            {"image-key": "managedcluster_import_controller", "konflux-component-name": "managedcluster-import-controller-addon", "publish-name": "managedcluster-import-controller-addon-rhel9"},
+            {"image-key": "managedcluster_import_controller", "konflux-component-name": "managedcluster-import-controller-addon", "publish-name": "managedcluster-import-controller-rhel9"},
             {"image-key": "managed_serviceaccount",           "konflux-component-name": "managed-serviceaccount", "publish-name": "managed-serviceaccount-rhel9"},
             {"image-key": "multicloud_manager",               "konflux-component-name": "multicloud-manager", "publish-name": "multicloud-manager-rhel9"},
-            {"image-key": "openshift_hive",                   "konflux-component-name": "hive", "publish-name": "hive-rhel9"},
             {"image-key": "provider_credential_controller",   "konflux-component-name": "provider-credential-controller", "publish-name": "provider-credential-controller-rhel9"},
             {"image-key": "placement",                        "konflux-component-name": "placement", "publish-name": "placement-rhel9"},
             {"image-key": "registration",                     "konflux-component-name": "registration", "publish-name": "registration-rhel9"},
@@ -37,6 +36,12 @@
     },
     "external-images": {
         "image-list": [
+            {
+              "image-key":          "openshift_hive",
+              "note-1":             "This is a placeholder image reference",
+              "pre-pub-image-ref":  "quay.io/acm-d/hive-rhel9:v2.9.0-1",
+              "as-pub-remote":      "registry.redhat.io/multicluster-engine"
+            },{
             {
               "image-key":          "assisted_image_service",
               "note-1":             "This is a placeholder image reference",
@@ -69,10 +74,10 @@
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":      "ose_cluster_api_rhel9",
-              "image-ref":      "registry.redhat.io/openshift4/ose-cluster-api-rhel9@sha256:0e3b3f1985392de570d296fc4067be16e303f37790292c93e94f7c387c765074"
+              "image-ref":      "registry.redhat.io/openshift4/ose-cluster-api-rhel9:v4.18"
             },{
               "image-key":      "ose_aws_cluster_api_controllers_rhel9",
-              "image-ref":      "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9@sha256:5aad0fe9dd1530fb0e2e7efd31dbd29bf29eb364717cc4822302eb197b558a1f"
+              "image-ref":      "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9:v4.18"
             },{
               "image-key":      "postgresql_12",
               "image-ref":      "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"


### PR DESCRIPTION
Some of the image references are not correct.  Moving hive to reference it as an external image since there are no builds  for it as an internal component.

Refs:
 - https://issues.redhat.com/browse/ACM-19994