### PR TITLE
Use the right kube-rbac-proxy name for mce

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -23,7 +23,7 @@
             {"image-key": "hypershift_cli",                   "konflux-component-name": "hypershift-cli", "publish-name": "hypershift-cli-rhel9"},
             {"image-key": "hypershift_operator",              "konflux-component-name": "hypershift-release", "publish-name": "hypershift-rhel9-operator"},
             {"image-key": "image_based_install_operator",     "konflux-component-name": "image-based-install-operator", "publish-name": "image-based-install-rhel9"},
-            {"image-key": "kube_rbac_proxy_mce",              "konflux-component-name": "kube-rbac-proxy", "publish-name": "kube-rbac-proxy-rhel9"},
+            {"image-key": "kube_rbac_proxy_mce",              "konflux-component-name": "kube-rbac-proxy", "publish-name": "kube-rbac-proxy-mce-rhel9"},
             {"image-key": "managedcluster_import_controller", "konflux-component-name": "managedcluster-import-controller-addon", "publish-name": "managedcluster-import-controller-rhel9"},
             {"image-key": "managed_serviceaccount",           "konflux-component-name": "managed-serviceaccount", "publish-name": "managed-serviceaccount-rhel9"},
             {"image-key": "multicloud_manager",               "konflux-component-name": "multicloud-manager", "publish-name": "multicloud-manager-rhel9"},


### PR DESCRIPTION
We had the wrong kube-rbac-proxy image name for mce