### PR TITLE
[ACM-21277] Updated CAP(x) image references to use images from registry.redhat.io

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -71,23 +71,16 @@
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "ose_cluster_api_rhel9",
-              "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/ose-cluster-api-rhel9:v4.19.0-202505200051.p0.g479f0c4.assembly.stream.el9",
-              "as-pub-remote":      "registry.redhat.io/openshift4"
+              "image-ref":          "registry.redhat.io/openshift4/ose-cluster-api-rhel9:v4.19"
             },{
               "image-key":          "ose_aws_cluster_api_controllers_rhel9",
-              "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/ose-aws-cluster-api-controllers-rhel9:v4.19.0-202505200051.p0.g8024520.assembly.stream.el9",
-              "as-pub-remote":      "registry.redhat.io/openshift4"
+              "image-ref":          "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9:v4.19"
             },{
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",
-              "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/ose-baremetal-cluster-api-controllers-rhel9:v4.19.0-202505200051.p0.g9e7170f.assembly.stream.el9",
-              "as-pub-remote":      "registry.redhat.io/openshift4"
-
+              "image-ref":          "registry.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.19"
             },{
-              "image-key":      "postgresql_12",
-              "image-ref":      "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"
+              "image-key":          "postgresql_12",
+              "image-ref":          "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"
             }
         ]
     }


### PR DESCRIPTION
# Description

For MCE 2.9, CAPI will utilize images for OCP 4.19. This PR updates the MCE operator bundle to reference the corresponding 4.19 images.

## Related Issue

https://issues.redhat.com/browse/ACM-21277

## Changes Made

Updated `config/mce-manifest-gen-config.json` and removed placeholder image references.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
