### PR TITLE
[ACM-21984] Updated gen-latest-snapshot github action to stage release plan

### DIFF
--- a/.github/workflows/gen-latest-snapshot.yaml
+++ b/.github/workflows/gen-latest-snapshot.yaml
@@ -18,7 +18,7 @@ jobs:
           branch: ['backplane-2.9']
           include:
             - branch: backplane-2.9
-              release-plan: "dev-publish-mce-29"
+              release-plan: "stage-publish-mce-29"
 
     steps:
       - name: Checkout tooling branch


### PR DESCRIPTION
# Description

To align with our staging release plan, this PR modifies the `gen-latest-snapshot.yaml` GitHub Action. By updating the `release-plan` variable to `stage-publish-mce-29`, we're now correctly targeting the staging environment for our latest snapshots.

## Related Issue

https://issues.redhat.com/browse/ACM-21984

## Changes Made

Updated `gen-latest-snapshot.yaml` to set the `release-plan` variable to `stage-publish-mce-29`.


## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin @eemurphy 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
