### PR TITLE
Switch to floating tag for picking up latest CAPI images

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -68,10 +68,10 @@
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":      "ose_cluster_api_rhel9",
-              "image-ref":      "registry.redhat.io/openshift4/ose-cluster-api-rhel9@sha256:0e3b3f1985392de570d296fc4067be16e303f37790292c93e94f7c387c765074"
+              "image-ref":      "registry.redhat.io/openshift4/ose-cluster-api-rhel9:v4.18"
             },{
               "image-key":      "ose_aws_cluster_api_controllers_rhel9",
-              "image-ref":      "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9@sha256:5aad0fe9dd1530fb0e2e7efd31dbd29bf29eb364717cc4822302eb197b558a1f"
+              "image-ref":      "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9:v4.18"
             },{
               "image-key":      "postgresql_12",
               "image-ref":      "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"


### PR DESCRIPTION
The digests being used don't exist.  For now we can switch to the floating tags and we can pin to a desired digest during FC or staging.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
