### PR TITLE
The capi images need to be the ocp 4.20 images

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -71,13 +71,19 @@
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "ose_cluster_api_rhel9",
-              "image-ref":          "registry.redhat.io/openshift4/ose-cluster-api-rhel9:v4.19"
+              "note-1":             "This is a placeholder image reference",
+              "pre-pub-image-ref":  "quay.io/acm-d/ose-cluster-api-rhel9:v4.20.0-202508121146.p0.gde1db29.assembly.stream.el9",
+              "as-pub-remote":      "registry.redhat.io/openshift4"
             },{
               "image-key":          "ose_aws_cluster_api_controllers_rhel9",
-              "image-ref":          "registry.redhat.io/openshift4/ose-aws-cluster-api-controllers-rhel9:v4.19"
+              "note-1":             "This is a placeholder image reference",
+              "pre-pub-image-ref":  "quay.io/acm-d/ose-aws-cluster-api-controllers-rhel9:v4.20.0-202508121146.p0.gd351913.assembly.stream.el9",
+              "as-pub-remote":      "registry.redhat.io/openshift4"
             },{
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",
-              "image-ref":          "registry.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.19"
+              "note-1":             "This is a placeholder image reference",
+              "pre-pub-image-ref":  "quay.io/acm-d/ose-baremetal-cluster-api-controllers-rhel9:v4.20.0-202508121146.p0.gf782ba7.assembly.stream.el9",
+              "as-pub-remote":      "registry.redhat.io/openshift4"
             },{
               "image-key":          "postgresql_12",
               "image-ref":          "registry.redhat.io/rhel8/postgresql-12:1-109.1655143367"


### PR DESCRIPTION
Point to the OCP 4.20 capi images.  The 4.19 images do not work with the resources that expect 4.20 images.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
