### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for mce-operator-bundle-mce-29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       vendor="Red Hat, Inc." \
       url="https://github.com/stolostron/mce-operator-bundle" \
       release="2.9.1-46" \
-      distribution-scope="public"
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
