### PR TITLE
Change the label selection based on current behavior

### DIFF
--- a/snapshot-collector.sh
+++ b/snapshot-collector.sh
@@ -3,7 +3,7 @@
 get_latest_release() {
   releasePlan=$1
   latestRelease=$(
-    oc get releases --sort-by=.metadata.creationTimestamp --selector=pac.test.appstudio.openshift.io/event-type=push |
+    oc get releases --sort-by=.metadata.creationTimestamp --selector=release.appstudio.openshift.io/automated=true |
       grep "Succeeded" |
       awk '$3 == "'"${releasePlan}"'" { print $1 }' |
       tail -1


### PR DESCRIPTION
The releases created and their labels seem to be different today than in the past.  I no longer see pull request releases and now the releases that are all push based have some different event-types like incoming for rebuild requests and retest-comment for retest requests. I'm not sure I want to focus on that label anymore so switching for the momment to a different label, but this is something to keep an eye on.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
