### PR TITLE
[ACM-24949] Update CAPA image reference to use internally built version in MCE 2.10

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -9,6 +9,7 @@
             {"image-key": "backplane_must_gather",                                 "konflux-component-name": "backplane-must-gather", "publish-name": "must-gather-rhel9"},
             {"image-key": "backplane_operator",                                    "konflux-component-name": "backplane-operator", "publish-name": "backplane-rhel9-operator"},
             {"image-key": "cluster_api_provider_agent",                            "konflux-component-name": "cluster-api-provider-agent", "publish-name": "cluster-api-provider-agent-rhel9"},
+            {"image-key": "cluster_api_provider_aws",                              "konflux-component-name": "cluster-api-provider-aws", "publish-name": "cluster-api-provider-aws-rhel9"},
             {"image-key": "cluster_api_provider_kubevirt",                         "konflux-component-name": "cluster-api-provider-kubevirt", "publish-name": "cluster-api-provider-kubevirt-rhel9"},
             {"image-key": "cluster_api_provider_openshift_assisted_bootstrap",     "konflux-component-name": "cluster-api-provider-openshift-assisted-bootstrap", "publish-name": "capoa-bootstrap-rhel9"},
             {"image-key": "cluster_api_provider_openshift_assisted_control_plane", "konflux-component-name": "cluster-api-provider-openshift-assisted-control-plane", "publish-name": "capoa-control-plane-rhel9"},
@@ -68,11 +69,6 @@
               "image-key":          "ose_cluster_api_rhel9",
               "note-1":             "This is a placeholder image reference",
               "pre-pub-image-ref":  "quay.io/acm-d/ose-cluster-api-rhel9:v4.20.0-202508121146.p0.gde1db29.assembly.stream.el9",
-              "as-pub-remote":      "registry.redhat.io/openshift4"
-            },{
-              "image-key":          "ose_aws_cluster_api_controllers_rhel9",
-              "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/ose-aws-cluster-api-controllers-rhel9:v4.20.0-202508121146.p0.gd351913.assembly.stream.el9",
               "as-pub-remote":      "registry.redhat.io/openshift4"
             },{
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",


### PR DESCRIPTION
# Description

Starting with MCE 2.10, the `cluster-api-provider-aws` (CAPA) component is now built internally and included in the MCE bundle. This PR updates the configuration to:

- Remove the external CAPA image reference.
- Replace it with the internally built CAPA image provided within the MCE 2.10 packaging.

## Related Issue

https://issues.redhat.com/browse/ACM-24949

## Changes Made

Replaced external CAPA image reference with internal MCE 2.10 bundled image.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
