### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for mce-operator-bundle-mce-29

### DIFF
--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -20,4 +20,5 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       vendor="Red Hat, Inc." \
       url="https://github.com/stolostron/mce-operator-bundle" \
       release="${BUNDLE_VERSION}" \
-      distribution-scope="public"
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"


### PR DESCRIPTION
# Description

For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also https://github.com/release-engineering/rhtap-ec-policy/pull/149

## Related Issue

https://issues.redhat.com/browse/KONFLUX-6210

## Changes Made

Updated `config/Dockerfile.in`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
