### PR TITLE
Fix MCE 5.0 snapshot schedule to avoid conflicts

### DIFF
--- a/.github/workflows/gen-latest-snapshot-mce-50.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-50.yaml
@@ -3,10 +3,8 @@ name: Gen Latest Dev Snapshot - MCE 5.0
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 3 * * *'   # 11:00PM EST every day (UTC-4)
-    - cron: '0 9 * * *'   # 5:00AM EST every day (UTC-4)
-    - cron: '0 15 * * *'  # 11:00AM EST every day (UTC-4)
-    - cron: '0 21 * * *'  # 5:00PM EST every day (UTC-4)
+    - cron: '0 2 * * *'   # 10:00PM EST every day (UTC-4)
+    - cron: '0 12 * * *'  # 8:00AM EST every day (UTC-4)
 
 jobs:
   snapshot:


### PR DESCRIPTION
# Description

Reduced MCE 5.0 dev snapshot builds from 4x to 2x daily and changed schedule from (3,9,15,21 UTC) to (2,12 UTC) to prevent conflicts and align with ACM 5.0 schedule.

New schedule: 10:00PM EST and 8:00AM EST (2x daily)

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
