### PR TITLE
Update external CAPI images to v4.22 for MCE 2.17

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -71,10 +71,10 @@
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "ose_cluster_api_rhel9",
-              "image-ref":          "registry.stage.redhat.io/openshift4/ose-cluster-api-rhel9:v4.21"
+              "image-ref":          "registry.stage.redhat.io/openshift4/ose-cluster-api-rhel9:v4.22"
             },{
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",
-              "image-ref":          "registry.stage.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.21"
+              "image-ref":          "registry.stage.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.22"
             },{
               "image-key":          "postgresql_13",
               "image-ref":          "registry.redhat.io/rhel9/postgresql-13:1-1766414400"


### PR DESCRIPTION
# Description

Update external CAPI (Cluster API) images to v4.22 for MCE 2.17, aligning with the supported OCP 4.22 version.

## Related Issue

N/A

## Changes Made

Updated the following image references in `config/mce-manifest-gen-config.json`:
- `ose_cluster_api_rhel9`: v4.21 -> v4.22
- `ose_baremetal_cluster_api_controllers_rhel9`: v4.21 -> v4.22

MCE 2.17 supports OCP 4.22, so the external Cluster API images need to be updated to match the supported OpenShift version.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This change is required to ensure MCE 2.17 uses the correct Cluster API provider images that correspond to the supported OCP 4.22 version.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster and bare metal cluster API components to version 4.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->