### PR TITLE
Fix weekly CVE scan workflow to use correct branch naming

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -12,16 +12,15 @@ on:
       release_branch:
         description: 'Release branch to scan'
         required: false
-        default: 'release-2.17'
+        default: 'backplane-2.17'
         type: choice
         options:
-          - release-2.17
-          - release-2.16
-          - release-2.15
-          - release-2.14
-          - release-2.13
-          - release-2.12
-          - release-2.11
+          - backplane-2.17
+          - backplane-2.11
+          - backplane-2.10
+          - backplane-2.9
+          - backplane-2.8
+          - backplane-2.7
           - all
       severity:
         description: 'CVE severity levels to scan'
@@ -37,13 +36,13 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["release-2.17", "release-2.16", "release-2.15"]') || inputs.release_branch == 'all' && fromJSON('["release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13", "release-2.12", "release-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-2.17", "backplane-2.11", "backplane-2.10"]') || inputs.release_branch == 'all' && fromJSON('["backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:
       # Use matrix value for scheduled runs, or workflow input for manual runs
       RELEASE_BRANCH: ${{ matrix.release_branch }}
-      ACM_VERSION: ${{ vars.ACM_VERSION || '' }}
+      ACM_VERSION: ${{ vars.ACM_VERSION || '' }}  # ACM_VERSION used by scripts (works for both ACM and MCE)
       SCAN_SEVERITY: ${{ inputs.severity || vars.SCAN_SEVERITY || 'HIGH,CRITICAL' }}
 
     steps:


### PR DESCRIPTION
# Description

This PR fixes the weekly CVE scan GitHub Action workflow to use the correct `backplane-*` branch naming convention for MCE, instead of the incorrect `release-*` naming that was causing workflow failures.

## Related Issue

Fixes the failing weekly CVE scan workflow: https://github.com/stolostron/mce-operator-bundle/actions/runs/24236569250/job/70760512981

The workflow was failing with:
```
The process '/usr/bin/git' failed with exit code 1
make: *** No rule to make target 'slack-cve-report'. Stop.
```

## Changes Made

1. **Updated branch naming from `release-*` to `backplane-*`**:
   - Default branch: `release-2.17` → `backplane-2.17`
   - Workflow dispatch options: All `release-*` → `backplane-*`
   - Scheduled scan matrix: Now scans `backplane-2.17`, `backplane-2.11`, `backplane-2.10`
   - All releases option: Includes `backplane-2.17` through `backplane-2.7`

2. **Added clarifying comment** for ACM_VERSION environment variable (works for both ACM and MCE)

The root cause was that MCE uses `backplane-*` branch naming (e.g., `backplane-2.17`, `backplane-2.11`) while the workflow was trying to checkout non-existent `release-*` branches, causing git checkout failures.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable). - N/A for workflow changes
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- The Makefile already has the correct `slack-cve-report` target on main branch
- The workflow already uses Grype (migrated from Trivy in commit 90459331)
- No changes needed to the scanning logic, only branch names

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the weekly CVE scan workflow to use a new release branch naming convention and adjusted scanned version coverage. The workflow now tracks an updated set of release versions for automated vulnerability scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->