### PR TITLE
Update assisted installer images for MCE 2.11.1

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -170,23 +170,23 @@
         "image-list": [
             {
                 "image-key": "assisted_image_service",
-                "image-ref": "registry.redhat.io/multicluster-engine/assisted-image-service-rhel9@sha256:22ee48612a7e4f7badd64b727339bce3a2d590ffae6c353872140fa2fae95e84"
+                "image-ref": "registry.redhat.io/multicluster-engine/assisted-image-service-rhel9@sha256:92f37d4e62d0be6705e275da4afcdbb5817bee2cffe10615c27935b0bebebccf"
             },
             {
                 "image-key": "assisted_installer",
-                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-rhel9@sha256:7b5990495b59646693dc7f6e6408db59cae1d780266b70001ab848275773fd5c"
+                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-rhel9@sha256:72e57d484d6ee1880f4ec7e9b324e0ea8dd69e21eaf9b96c9a7e502f3d4af8ad"
             },
             {
                 "image-key": "assisted_installer_agent",
-                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9@sha256:5189821ba937e95b6ebba3ac6aa7b880ade6ac184175f5c3f380c8973742a20a"
+                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-agent-rhel9@sha256:995f9b9a4727db219c5db7abfbec189c51c169460e9953940ab88bb8d3c47613"
             },
             {
                 "image-key": "assisted_installer_controller",
-                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-controller-rhel9@sha256:1fcbba2bf725e886f67b4d4280915733dfaa58a1826e38d536a751ee3453a235"
+                "image-ref": "registry.redhat.io/multicluster-engine/assisted-installer-controller-rhel9@sha256:fdc0d540b6161016c067f694ca727c9f5cf857f7df2f199e1490879c39cb8036"
             },
             {
                 "image-key": "assisted_service_9",
-                "image-ref": "registry.redhat.io/multicluster-engine/assisted-service-9-rhel9@sha256:8176f9220a1eccabab8ba561ef0264be16ead2a0888479fd034535fdcf65e976"
+                "image-ref": "registry.redhat.io/multicluster-engine/assisted-service-9-rhel9@sha256:ff4f6ed0dc07e2be6093e4532232d73d3e27e92b615608abf93e5dbd6d329c2e"
             },
             {
                 "image-key": "ose_cluster_api_rhel9",


### PR DESCRIPTION
# Description

Updates the image SHAs for assisted installer images for MCE 2.11.1

Based off of https://gitlab.cee.redhat.com/acm/acm-release-management/-/merge_requests/136/diffs

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin @pastequo @gamli75 

