### PR TITLE
Add user mention on mirror failures

### DIFF
--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -162,6 +162,7 @@ jobs:
       env:
         EVENT_NAME: ${{ github.event_name }}
         REF_NAME: ${{ github.ref_name }}
+        SLACK_USER_ID: ${{ vars.SLACK_USER_ID }}
       run: |
         # Read results from the JSON file
         if [ ! -f workflow/mirror-results.json ]; then
@@ -169,6 +170,7 @@ jobs:
           STATUS="❌ *FAILED*"
           SUMMARY="Mirror script did not complete successfully"
           DETAILS=""
+          HAS_FAILURE=true
         else
           # Parse the JSON results
           MIRRORED=$(jq -r '.mirrored' workflow/mirror-results.json)
@@ -179,10 +181,13 @@ jobs:
           # Determine status
           if [ "$FAILED" -gt 0 ]; then
             STATUS="⚠️ *COMPLETED WITH FAILURES*"
+            HAS_FAILURE=true
           elif [ "$DRY_RUN" = "true" ]; then
             STATUS="🔍 *DRY RUN COMPLETED*"
+            HAS_FAILURE=false
           else
             STATUS="✅ *SUCCESS*"
+            HAS_FAILURE=false
           fi
 
           # Build summary
@@ -195,6 +200,12 @@ jobs:
             FAILURES=$(jq -r '.failures[] | "• `\(.image_key)` [\(.operator)]\n  Source: `\(.source)`\n  Target: `\(.target)`\n  Error: \(.error)\n"' workflow/mirror-results.json)
             DETAILS="$DETAILS$FAILURES"
           fi
+        fi
+
+        # Add user mention if there's a failure and SLACK_USER_ID is set
+        USER_MENTION=""
+        if [ "$HAS_FAILURE" = "true" ] && [ -n "$SLACK_USER_ID" ]; then
+          USER_MENTION=" <@$SLACK_USER_ID>"
         fi
 
         # Build the Slack message
@@ -213,7 +224,7 @@ jobs:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "$STATUS\n\n$SUMMARY$DETAILS"
+                "text": "$STATUS$USER_MENTION\n\n$SUMMARY$DETAILS"
               }
             },
             {


### PR DESCRIPTION
## Summary

Add `SLACK_USER_ID` variable to mention user only when image mirror workflow fails.

## Changes

- Add `SLACK_USER_ID` env var to Slack notification step (uses repository variable)
- Track failure state with `HAS_FAILURE` flag
- Add user mention logic: append `<@USER_ID>` to status when failures occur
- User mentioned in two scenarios:
  - ❌ Script crash (no results file)
  - ⚠️ Partial failures (FAILED > 0)

## Behavior

**With failures:** `❌ *FAILED* <@USER_ID>`  
**Success:** `✅ *SUCCESS*` (no mention)  
**Dry-run:** `🔍 *DRY RUN COMPLETED*` (no mention)

Backwards compatible: if `SLACK_USER_ID` not set, no mention added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)