### PR TITLE
Restore mce-manifest-gen-config to match backplane-2.17

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -6,11 +6,13 @@
 
         "image-list": [
             {"image-key": "addon_manager",                                         "konflux-component-name": "addon-manager", "publish-name": "addon-manager-rhel9"},
+            {"image-key": "azure_service_operator_rhel9",                          "konflux-component-name": "azure-service-operator", "publish-name": "azure-service-operator-rhel9"},
             {"image-key": "backplane_must_gather",                                 "konflux-component-name": "backplane-must-gather", "publish-name": "must-gather-rhel9"},
             {"image-key": "backplane_operator",                                    "konflux-component-name": "backplane-operator", "publish-name": "backplane-rhel9-operator"},
-            {"image-key": "cloudevents-conductor",                                 "konflux-component-name": "cloudevents-conductor", "publish-name": "cloudevents-conductor-rhel9"},
+            {"image-key": "cloudevents_conductor",                                 "konflux-component-name": "cloudevents-conductor", "publish-name": "cloudevents-conductor-rhel9"},
             {"image-key": "cluster_api_provider_agent",                            "konflux-component-name": "cluster-api-provider-agent", "publish-name": "cluster-api-provider-agent-rhel9"},
             {"image-key": "cluster_api_provider_aws_rhel9",                        "konflux-component-name": "cluster-api-provider-aws", "publish-name": "cluster-api-provider-aws-rhel9"},
+            {"image-key": "cluster_api_provider_azure_rhel9",                      "konflux-component-name": "cluster-api-provider-azure", "publish-name": "cluster-api-provider-azure-rhel9"},
             {"image-key": "cluster_api_provider_kubevirt",                         "konflux-component-name": "cluster-api-provider-kubevirt", "publish-name": "cluster-api-provider-kubevirt-rhel9"},
             {"image-key": "cluster_api_provider_openshift_assisted_bootstrap",     "konflux-component-name": "cluster-api-provider-openshift-assisted-bootstrap", "publish-name": "capoa-bootstrap-rhel9"},
             {"image-key": "cluster_api_provider_openshift_assisted_control_plane", "konflux-component-name": "cluster-api-provider-openshift-assisted-control-plane", "publish-name": "capoa-control-plane-rhel9"},
@@ -19,7 +21,7 @@
             {"image-key": "cluster_curator_controller",                            "konflux-component-name": "cluster-curator-controller", "publish-name": "cluster-curator-controller-rhel9"},
             {"image-key": "cluster_image_set_controller",                          "konflux-component-name": "cluster-image-set-controller", "publish-name": "cluster-image-set-controller-rhel9"},
             {"image-key": "clusterlifecycle_state_metrics",                        "konflux-component-name": "clusterlifecycle-state-metrics", "publish-name": "clusterlifecycle-state-metrics-rhel9"},
-            {"image-key": "cluster_proxy_addon",                                   "konflux-component-name": "cluster-proxy-addon", "publish-name": "cluster-proxy-addon-rhel9"},
+            {"image-key": "cluster_permission",                                    "konflux-component-name": "cluster-permission", "publish-name": "acm-cluster-permission-rhel9"},
             {"image-key": "cluster_proxy",                                         "konflux-component-name": "cluster-proxy", "publish-name": "cluster-proxy-rhel9"},
             {"image-key": "console_mce",                                           "konflux-component-name": "console-mce", "publish-name": "console-mce-rhel9"},
             {"image-key": "discovery_operator",                                    "konflux-component-name": "discovery-operator", "publish-name": "discovery-rhel9"},
@@ -45,37 +47,40 @@
             {
               "image-key":          "assisted_image_service",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-image-service-rhel9:v2.10-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-image-service-rhel9:v2.17-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-rhel9:v2.10-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-rhel9:v2.17-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer_agent",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-agent-rhel9:v2.10-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-agent-rhel9:v2.17-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer_controller",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-controller-rhel9:v2.10-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-controller-rhel9:v2.17-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_service_9",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-service-9-rhel9:v2.10-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-service-9-rhel9:v2.17-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "ose_cluster_api_rhel9",
-              "image-ref":          "registry.redhat.io/openshift4/ose-cluster-api-rhel9:v4.20.0-202509230043.p2.gde1db29.assembly.stream.el9"
+              "image-ref":          "registry.stage.redhat.io/openshift4/ose-cluster-api-rhel9:v4.22"
             },{
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",
-              "image-ref":          "registry.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.20"
+              "image-ref":          "registry.stage.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.22"
             },{
-              "image-key":          "postgresql_12",
-              "image-ref":          "registry.redhat.io/rhel8/postgresql-12:1-1756930566"
+              "image-key":          "postgresql_13",
+              "image-ref":          "registry.redhat.io/rhel9/postgresql-13:1-1766414400"
+            },{
+              "image-key":          "postgresql_15",
+              "image-ref":          "registry.redhat.io/rhel9/postgresql-15:1-1775009263"
             }
         ]
     }


### PR DESCRIPTION
## Summary
- Add back Azure images (azure_service_operator_rhel9, cluster_api_provider_azure_rhel9)
- Fix image keys to match backplane-2.17 naming (cloudevents_conductor, cluster_permission)
- Update assisted installer images from v2.10-latest to v2.17-latest
- Update cluster API images from v4.20 to v4.22 with stage registry
- Replace postgresql_12 with postgresql_13 and postgresql_15

## Test plan
- [ ] Verify config diff matches expected changes from backplane-2.17
- [ ] Validate JSON syntax
- [ ] Test manifest generation with updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)