### PR TITLE
Update release version mappings to match branch versions

### DIFF
--- a/.github/release-version-mapping.yaml
+++ b/.github/release-version-mapping.yaml
@@ -3,12 +3,12 @@
 # to automatically update Z_RELEASE_VERSION files in each release branch
 
 release_mappings:
-  backplane-2.6: "2.6.10"
-  backplane-2.7: "2.7.9"  
-  backplane-2.8: "2.8.5"
-  backplane-2.9: "2.9.3"
-  backplane-2.10: "2.10.2"
-  backplane-2.11: "2.11.1"
+  backplane-2.6: "2.6.11"
+  backplane-2.7: "2.7.11"
+  backplane-2.8: "2.8.6"
+  backplane-2.9: "2.9.4"
+  backplane-2.10: "2.10.3"
+  backplane-2.11: "2.11.2"
   backplane-2.17: "2.17.0"
   backplane-5.0: "5.0.0"
   # Add new release mappings here as needed


### PR DESCRIPTION
## Summary
Sync release-version-mapping.yaml with actual Z_RELEASE_VERSION values in backplane branches.

## Changes
- `backplane-2.6`: 2.6.10 → 2.6.11
- `backplane-2.7`: 2.7.9 → 2.7.11
- `backplane-2.8`: 2.8.5 → 2.8.6
- `backplane-2.9`: 2.9.3 → 2.9.4
- `backplane-2.10`: 2.10.2 → 2.10.3
- `backplane-2.11`: 2.11.1 → 2.11.2

## Context
Main branch mapping was stale. Backplane branches already had newer patch versions built and merged. This update ensures the mapping file reflects current state.

## Testing
Once merged, update-release-versions workflow will run and verify mappings match branch versions.