### PR TITLE
Set add_iteration_suffix to 0 for 2.17

### DIFF
--- a/config/mce-bundle-gen-config
+++ b/config/mce-bundle-gen-config
@@ -75,7 +75,7 @@ image_manifest_gen_config_file="config/mce-manifest-gen-config.json"
 ignore_image_errors=1
 
 # Set to non-zero to have iteration/build-number suffixes appended to bundle versions.
-add_iteration_suffix=1
+add_iteration_suffix=0
 
 #----------------------------------------------------
 # Config properties likely the same for all products


### PR DESCRIPTION
## Summary
- Set `add_iteration_suffix=0` in `config/mce-bundle-gen-config` to disable iteration/build-number suffixes on bundle versions for the 2.17 release.