### PR TITLE
Filter unfixable CVEs from weekly Slack reports

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -37,7 +37,7 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11"]') || inputs.release_branch == 'all' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9"]') || inputs.release_branch == 'all' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:
@@ -252,6 +252,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CVE_CHANNEL }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          FILTER_UNFIXABLE: true
 
       - name: Upload CVE reports
         if: always()

--- a/scripts/slack_cve_report.py
+++ b/scripts/slack_cve_report.py
@@ -54,7 +54,7 @@ def load_previous_scan_results(previous_reports_dir, version):
         if filename.startswith(f"{version}_") and filename.endswith("_grype.json"):
             image_key = filename.replace(f"{version}_", "").replace("_grype.json", "")
 
-            cve_data = parse_grype_json(json_file)
+            cve_data = parse_grype_json(json_file, filter_unfixable=False)
             if cve_data:
                 previous_results[image_key] = cve_data
 
@@ -179,8 +179,13 @@ def parse_cve_summary(summary_file):
     return results, total_scanned, total_failed
 
 
-def parse_grype_json(json_file):
-    """Parse Grype JSON output to count CVEs by severity"""
+def parse_grype_json(json_file, filter_unfixable=False):
+    """Parse Grype JSON output to count CVEs by severity
+
+    Args:
+        json_file: Path to Grype JSON report
+        filter_unfixable: If True, exclude CVEs with no fix available
+    """
     try:
         with open(json_file, 'r') as f:
             data = json.load(f)
@@ -221,6 +226,9 @@ def parse_grype_json(json_file):
                 has_fix += 1
             else:
                 no_fix += 1
+                # Skip non-fixable CVEs if filter enabled
+                if filter_unfixable:
+                    continue
 
             if severity == 'CRITICAL':
                 critical += 1
@@ -732,6 +740,7 @@ def main():
     format_type = os.getenv('SLACK_FORMAT', 'summary')  # summary or detailed
     use_threading = os.getenv('SLACK_USE_THREADING', 'true').lower() == 'true'
     previous_reports_dir = os.getenv('PREVIOUS_REPORTS_DIR', None)  # Optional: path to previous scan reports
+    filter_unfixable = os.getenv('FILTER_UNFIXABLE', 'false').lower() == 'true'  # Filter out non-fixable CVEs
 
     # Determine mode: threaded (bot token) or webhook
     if bot_token and channel and use_threading:
@@ -793,7 +802,7 @@ def main():
             txt_report = reports_path / f"{version}_{image_key}_grype.txt"
         
         if json_report.exists():
-            cve_count = parse_grype_json(json_report)
+            cve_count = parse_grype_json(json_report, filter_unfixable=filter_unfixable)
             if cve_count:
                 results.append({
                     'image': image_key,

--- a/scripts/slack_cve_report.py
+++ b/scripts/slack_cve_report.py
@@ -91,11 +91,12 @@ def compare_scan_results(current_results, previous_results):
         'net_change': {'critical': 0, 'high': 0, 'total': 0}
     }
 
-    # Build dict of current results
+    # Build dict of current results (use unfiltered counts for comparison)
     current_dict = {}
     for result in current_results:
         if result['status'] == 'success' and result.get('cve_count'):
-            current_dict[result['image']] = result['cve_count']
+            # Use unfiltered counts for baseline comparison, fallback to filtered if missing
+            current_dict[result['image']] = result.get('cve_count_unfiltered', result['cve_count'])
 
     # Calculate totals
     current_total_critical = sum(cve.get('critical', 0) for cve in current_dict.values())
@@ -802,12 +803,17 @@ def main():
             txt_report = reports_path / f"{version}_{image_key}_grype.txt"
         
         if json_report.exists():
+            # Parse with filtering for display
             cve_count = parse_grype_json(json_report, filter_unfixable=filter_unfixable)
-            if cve_count:
+            # Always parse unfiltered for baseline comparison
+            cve_count_unfiltered = parse_grype_json(json_report, filter_unfixable=False)
+
+            if cve_count and cve_count_unfiltered:
                 results.append({
                     'image': image_key,
                     'status': 'success',
-                    'cve_count': cve_count
+                    'cve_count': cve_count,
+                    'cve_count_unfiltered': cve_count_unfiltered
                 })
             else:
                 # JSON parse failed, treat as failed


### PR DESCRIPTION
## Summary
Filter unfixable CVEs from weekly Slack reports to reduce noise and focus on actionable vulnerabilities.

## Changes
- Added `FILTER_UNFIXABLE` env var to weekly CVE scan workflow
- Updated `parse_grype_json()` to skip CVEs with no fix available when filter enabled
- Expanded scheduled scan coverage from 3 to 5 releases (backplane-5.0, 2.17, 2.11-2.9)
- Keep previous scan comparison unfiltered for accurate delta tracking

## Impact
- **Slack reports**: Show only fixable CVEs (actionable items)
- **Artifacts**: Still contain full scan data (all CVEs) for audit/compliance
- **Scheduled scans**: Now cover 5 releases instead of 3

## Test Plan
- [x] Verified filter logic in parse_grype_json()
- [ ] Manual workflow run to confirm Slack output
- [ ] Check DCO signoff passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Expanded weekly CVE scan matrix to include Backplane releases 2.9 and 2.10
* Added optional filtering to exclude unfixable vulnerabilities from CVE reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->