### PR TITLE
[ACM-33645] Update PostgreSQL image to version 16 for MCE

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -81,6 +81,9 @@
             },{
               "image-key":          "postgresql_15",
               "image-ref":          "registry.redhat.io/rhel9/postgresql-15:1-1775009263"
+            },{
+              "image-key":          "postgresql_16",
+              "image-ref":          "registry.redhat.io/rhel9/postgresql-16:1-1779857114"
             }
         ]
     }


### PR DESCRIPTION
# Description

Updates the PostgreSQL image reference from postgresql-15 to postgresql-16 for ACM 5.0 / MCE 5.0.

## Related Issue

https://redhat.atlassian.net/browse/ACM-33645

## Changes Made

- Added `postgresql_16` entry to `config/mce-manifest-gen-config.json`
- Image: `registry.redhat.io/rhel9/postgresql-16:1-1779857114`
- Keeps `postgresql_15` alongside `postgresql_16` (both present)

## Additional Notes

Following the same upgrade pattern as PG13→PG15 (PR #2731):
- PG16 is added alongside PG15 first
- PG15 will be removed in a follow-up after backplane-operator merges

This is the first step for the MCE 5.0 PostgreSQL upgrade.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have rebased my branch on top of the latest backplane-5.0 branch.