### PR TITLE
Update snapshot for mce 2.10.3

### DIFF
--- a/latest-snapshot.yaml
+++ b/latest-snapshot.yaml
@@ -7,55 +7,61 @@ metadata:
     build.appstudio.redhat.com/target_branch: backplane-2.10
     pac.test.appstudio.openshift.io/branch: backplane-2.10
     pac.test.appstudio.openshift.io/cancel-in-progress: "false"
-    pac.test.appstudio.openshift.io/check-run-id: "79261434777"
+    pac.test.appstudio.openshift.io/check-run-id: "79260611206"
     pac.test.appstudio.openshift.io/controller-info: '{"name":"default","configmap":"pipelines-as-code","secret":"pipelines-as-code-secret",
       "gRepo": "pipelines-as-code"}'
-    pac.test.appstudio.openshift.io/event-type: incoming
-    pac.test.appstudio.openshift.io/git-auth-secret: pac-gitauth-tfwwin
+    pac.test.appstudio.openshift.io/event-type: push
+    pac.test.appstudio.openshift.io/git-auth-secret: pac-gitauth-tobdfo
     pac.test.appstudio.openshift.io/git-provider: github
     pac.test.appstudio.openshift.io/installation-id: "37784342"
-    pac.test.appstudio.openshift.io/log-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/pipelinerun/cluster-api-provider-openshift-assisted-control-plane-mce-5zxqx
+    pac.test.appstudio.openshift.io/log-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/pipelinerun/cluster-api-provider-openshift-assisted-control-plane-mce-4tmbd
     pac.test.appstudio.openshift.io/max-keep-runs: "3"
     pac.test.appstudio.openshift.io/on-cel-expression: event == "push" && target_branch
       == "backplane-2.10"
     pac.test.appstudio.openshift.io/original-prname: cluster-api-provider-openshift-assisted-control-plane-mce-210-on-push
+    pac.test.appstudio.openshift.io/pull-request: "711"
     pac.test.appstudio.openshift.io/repo-url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
     pac.test.appstudio.openshift.io/repository: cluster-api-provider-openshift-assisted-bootstrap-mce-29
     pac.test.appstudio.openshift.io/scm-reporting-plr-started: "true"
-    pac.test.appstudio.openshift.io/sender: incoming
+    pac.test.appstudio.openshift.io/sender: openshift-merge-bot[bot]
     pac.test.appstudio.openshift.io/sha: e84564ea6f6ea150590ff93aa58fc0c2feac449a
-    pac.test.appstudio.openshift.io/sha-title: 'Merge pull request #711 from openshift-assisted/konflux/references/backplane-2.10'
+    pac.test.appstudio.openshift.io/sha-title: |-
+      Merge pull request #711 from openshift-assisted/konflux/references/backplane-2.10
+
+      NO-ISSUE: Update Konflux references (backplane-2.10)
     pac.test.appstudio.openshift.io/sha-url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted/commit/e84564ea6f6ea150590ff93aa58fc0c2feac449a
-    pac.test.appstudio.openshift.io/source-branch: backplane-2.10
-    pac.test.appstudio.openshift.io/source-repo-url: ""
+    pac.test.appstudio.openshift.io/source-branch: refs/heads/backplane-2.10
+    pac.test.appstudio.openshift.io/source-repo-url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
     pac.test.appstudio.openshift.io/state: completed
     pac.test.appstudio.openshift.io/url-org: openshift-assisted
     pac.test.appstudio.openshift.io/url-repository: cluster-api-provider-openshift-assisted
-    test.appstudio.openshift.io/added-to-global-candidate-list: '{"result":true,"reason":"Success","lastupdatedtime":"2026-06-03T09:30:46Z"}'
-    test.appstudio.openshift.io/git-reporter-status: '{"scenarios":{"enterprise-contract-mce-210-release-mce-210-20260603-091813-000":{"lastUpdateTime":"2026-06-03T09:31:45.312688746Z"}}}'
+    test.appstudio.openshift.io/added-to-global-candidate-list: '{"result":true,"reason":"Success","lastupdatedtime":"2026-06-03T09:22:17Z"}'
+    test.appstudio.openshift.io/git-reporter-status: '{"scenarios":{"enterprise-contract-mce-210-release-mce-210-20260603-091330-000":{"lastUpdateTime":"2026-06-03T09:23:20.110586371Z"}}}'
     test.appstudio.openshift.io/integration-workflow: push
-    test.appstudio.openshift.io/pipelinerunstarttime: "1780478293000"
+    test.appstudio.openshift.io/pipelinerunstarttime: "1780478010000"
+    test.appstudio.openshift.io/pr-status: merged
     test.appstudio.openshift.io/source-repo-url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
-    test.appstudio.openshift.io/status: '[{"scenario":"enterprise-contract-mce-210","status":"BuildPLRInProgress","lastUpdateTime":"2026-06-03T09:31:45.312688746Z","details":"Integration
-      test passed with warnings","startTime":"2026-06-03T09:30:46.623901825Z","completionTime":"2026-06-03T09:31:45.312688746Z","testPipelineRunName":"enterprise-contract-mce-210-6gj9h"}]'
-  creationTimestamp: "2026-06-03T09:30:46Z"
+    test.appstudio.openshift.io/status: '[{"scenario":"enterprise-contract-mce-210","status":"BuildPLRInProgress","lastUpdateTime":"2026-06-03T09:23:20.110586371Z","details":"Integration
+      test passed with warnings","startTime":"2026-06-03T09:22:17.253047236Z","completionTime":"2026-06-03T09:23:20.110586371Z","testPipelineRunName":"enterprise-contract-mce-210-6sqgh"}]'
+  creationTimestamp: "2026-06-03T09:22:17Z"
   generation: 1
   labels:
     appstudio.openshift.io/application: release-mce-210
-    appstudio.openshift.io/build-pipelinerun: cluster-api-provider-openshift-assisted-control-plane-mce-5zxqx
+    appstudio.openshift.io/build-pipelinerun: cluster-api-provider-openshift-assisted-control-plane-mce-4tmbd
     appstudio.openshift.io/component: cluster-api-provider-openshift-assisted-control-plane-mce-210
     pac.test.appstudio.openshift.io/cancel-in-progress: "false"
-    pac.test.appstudio.openshift.io/check-run-id: "79261434777"
-    pac.test.appstudio.openshift.io/event-type: incoming
+    pac.test.appstudio.openshift.io/check-run-id: "79260611206"
+    pac.test.appstudio.openshift.io/event-type: push
     pac.test.appstudio.openshift.io/original-prname: api-provider-openshift-assisted-control-plane-mce-210-on-push
+    pac.test.appstudio.openshift.io/pull-request: "711"
     pac.test.appstudio.openshift.io/repository: cluster-api-provider-openshift-assisted-bootstrap-mce-29
     pac.test.appstudio.openshift.io/sha: e84564ea6f6ea150590ff93aa58fc0c2feac449a
     pac.test.appstudio.openshift.io/state: completed
     pac.test.appstudio.openshift.io/url-org: openshift-assisted
     pac.test.appstudio.openshift.io/url-repository: cluster-api-provider-openshift-assisted
-    test.appstudio.openshift.io/pipelinerunfinishtime: "1780479041"
+    test.appstudio.openshift.io/pipelinerunfinishtime: "1780478532"
     test.appstudio.openshift.io/type: component
-  name: release-mce-210-20260603-091813-000
+  name: release-mce-210-20260603-091330-000
   namespace: crt-redhat-acm-tenant
   ownerReferences:
   - apiVersion: appstudio.redhat.com/v1alpha1
@@ -64,119 +70,13 @@ metadata:
     kind: Application
     name: release-mce-210
     uid: 991ec411-638f-453f-837e-5b8d3562aa61
-  resourceVersion: "9163035883"
-  uid: 09a438e4-898c-455f-a0c9-0dff8dea08be
+  resourceVersion: "9162863126"
+  uid: 3773c16b-9449-4e4b-b254-721d0ee264a0
 spec:
   application: release-mce-210
   artifacts: {}
   componentGroup: ""
   components:
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/image-based-install-operator-mce-210@sha256:6504889416c49644317604766fc02a89e249eebebff9d05672e0bc9b84d3f055
-    name: image-based-install-operator-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: Dockerfile
-        revision: 5e6c12ba2c9cd554b31af18ebb404ed79471460d
-        url: https://github.com/openshift/image-based-install-operator
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/backplane-operator-mce-210@sha256:b569224e140f4ae667ee5810ed76b954d41a86f2f2f050c67161246e30647d85
-    name: backplane-operator-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: Dockerfile.rhtap
-        revision: a6348b4d216baf92ef44e5ee0d1610c46ec6b531
-        url: https://github.com/stolostron/backplane-operator
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-openshift-assisted-control-plane-mce-210@sha256:161ad58c3c55c5eed30432c8e80de97ebf20b3473fe1bbb617545793d58e488c
-    name: cluster-api-provider-openshift-assisted-control-plane-mce-210
-    source:
-      git:
-        revision: e84564ea6f6ea150590ff93aa58fc0c2feac449a
-        url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-proxy-mce-210@sha256:ceb7a3ee960c5af50f2b40ad8ae48eaceca17391df8e2acbb229d5807e5acfee
-    name: cluster-proxy-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: cmd/Dockerfile.rhtap
-        revision: 168a1b0a9c53df78099cde366223b77885e262b2
-        url: https://github.com/stolostron/cluster-proxy
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-addon-operator-mce-210@sha256:ab4439fa2601708d418342d666d3e147251b3676a1167394f02961db000762fa
-    name: hypershift-addon-operator-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: Dockerfile.rhtap
-        revision: 2e9a25ea112cb5ccab7bab69d82fc9040d76232f
-        url: https://github.com/stolostron/hypershift-addon-operator
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cli-mce-210@sha256:584933f9b8245767071b3baf5efbd6621fe0c9d7725fd70d4e9ebc8fe4376999
-    name: hypershift-cli-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: Containerfile.cli
-        revision: fc276eb854a93bb78255b435340069562061f620
-        url: https://github.com/openshift/hypershift
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-210@sha256:99d019bba760b9778bad810b4edf40d19a15bca0653f03b33b63a99e63fc1660
-    name: registration-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: build/Dockerfile.registration.rhtap
-        revision: 49a443608767503fe1ce3d56d5ccdb20584a8e49
-        url: https://github.com/stolostron/ocm
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-210@sha256:78dc423953fe22525dbc8c63e286d2bf27a62373af6230f33bcaf76a76780b73
-    name: work-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: build/Dockerfile.work.rhtap
-        revision: 49a443608767503fe1ce3d56d5ccdb20584a8e49
-        url: https://github.com/stolostron/ocm
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-210@sha256:f8bfc691c14802ed529dd2c30bce9bda77b38f8cc751993138b7c1a886303a26
-    name: cluster-api-provider-agent-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: Dockerfile.rhtap
-        revision: c9e1cc7e5170dd33b931d9b5050047bbe8576008
-        url: https://github.com/openshift/cluster-api-provider-agent
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-210@sha256:f006e44ed97ffad0d0bf6437ed8f60467b2ef9e4fdf14bfa02ce3897384b055b
-    name: cluster-api-provider-aws-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: stolostron/Dockerfile.stolostron
-        revision: 61b4b150558453c2b66c5e24053930aaca494e83
-        url: https://github.com/stolostron/cluster-api-provider-aws
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-webhook-config-mce-210@sha256:4bdd058f1e3c430fb3eb35869c931528f9857867dc3526268fef2ecf90e2330d
-    name: cluster-api-webhook-config-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: mce-capi-webhook-config/Dockerfile
-        revision: 5e1d847edcae78a3dd9ca86b53cfa2b9838a0028
-        url: https://github.com/stolostron/cluster-api-installer
-    version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/clusterlifecycle-state-metrics-mce-210@sha256:ffd266cad8abbbea68bc0bbd3732a1686871f2c0a99b4b8157384966a49809f4
-    name: clusterlifecycle-state-metrics-mce-210
-    source:
-      git:
-        context: ./
-        dockerfileUrl: build/Dockerfile.rhtap
-        revision: 3bebb8fc7adf4f89dee215085270860f165dc09d
-        url: https://github.com/stolostron/clusterlifecycle-state-metrics
-    version: ""
   - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hive-mce-210@sha256:f95b254d99badb27f7597f73e42fd2566558982a42818f929a02cfce34d1f4f8
     name: hive-mce-210
     source:
@@ -222,13 +122,13 @@ spec:
         revision: 28b70948e316d2ae42b6a991060a97b7fb332417
         url: https://github.com/openshift/cluster-api-provider-kubevirt
     version: ""
-  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-openshift-assisted-bootstrap-mce-210@sha256:66c0cae0eedd293bf92a1953be6d7485d63dabd5bab9ced7bb327df6cbe9affc
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-openshift-assisted-bootstrap-mce-210@sha256:9e6678f08cda6cbbdd720dea20c73b4f65eb3bade3b9a4b18df63d4ce5b1d892
     name: cluster-api-provider-openshift-assisted-bootstrap-mce-210
     source:
       git:
         context: ./
         dockerfileUrl: Dockerfile.bootstrap-provider
-        revision: e84564ea6f6ea150590ff93aa58fc0c2feac449a
+        revision: 616dfc376baa41d2b22d824aac30a346f2fee92c
         url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
     version: ""
   - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/kube-rbac-proxy-mce-210@sha256:e58bf69af1aa238f2d48094b33b27dec451fe85690addd6a87bb0a1bb9b08cc5
@@ -348,20 +248,126 @@ spec:
         revision: e3e6deae5faf5089bee6a99ca137127d6ad23ae1
         url: https://github.com/stolostron/provider-credential-controller
     version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/image-based-install-operator-mce-210@sha256:6504889416c49644317604766fc02a89e249eebebff9d05672e0bc9b84d3f055
+    name: image-based-install-operator-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: Dockerfile
+        revision: 5e6c12ba2c9cd554b31af18ebb404ed79471460d
+        url: https://github.com/openshift/image-based-install-operator
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/backplane-operator-mce-210@sha256:b569224e140f4ae667ee5810ed76b954d41a86f2f2f050c67161246e30647d85
+    name: backplane-operator-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: Dockerfile.rhtap
+        revision: a6348b4d216baf92ef44e5ee0d1610c46ec6b531
+        url: https://github.com/stolostron/backplane-operator
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-openshift-assisted-control-plane-mce-210@sha256:8d3609c98588ff6557019518a8e61f6df1e404d25c35252d4ada67b2e64de5ef
+    name: cluster-api-provider-openshift-assisted-control-plane-mce-210
+    source:
+      git:
+        revision: e84564ea6f6ea150590ff93aa58fc0c2feac449a
+        url: https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-proxy-mce-210@sha256:ceb7a3ee960c5af50f2b40ad8ae48eaceca17391df8e2acbb229d5807e5acfee
+    name: cluster-proxy-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: cmd/Dockerfile.rhtap
+        revision: 168a1b0a9c53df78099cde366223b77885e262b2
+        url: https://github.com/stolostron/cluster-proxy
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-addon-operator-mce-210@sha256:ab4439fa2601708d418342d666d3e147251b3676a1167394f02961db000762fa
+    name: hypershift-addon-operator-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: Dockerfile.rhtap
+        revision: 2e9a25ea112cb5ccab7bab69d82fc9040d76232f
+        url: https://github.com/stolostron/hypershift-addon-operator
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cli-mce-210@sha256:584933f9b8245767071b3baf5efbd6621fe0c9d7725fd70d4e9ebc8fe4376999
+    name: hypershift-cli-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: Containerfile.cli
+        revision: fc276eb854a93bb78255b435340069562061f620
+        url: https://github.com/openshift/hypershift
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/registration-mce-210@sha256:99d019bba760b9778bad810b4edf40d19a15bca0653f03b33b63a99e63fc1660
+    name: registration-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: build/Dockerfile.registration.rhtap
+        revision: 49a443608767503fe1ce3d56d5ccdb20584a8e49
+        url: https://github.com/stolostron/ocm
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/work-mce-210@sha256:78dc423953fe22525dbc8c63e286d2bf27a62373af6230f33bcaf76a76780b73
+    name: work-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: build/Dockerfile.work.rhtap
+        revision: 49a443608767503fe1ce3d56d5ccdb20584a8e49
+        url: https://github.com/stolostron/ocm
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-210@sha256:f8bfc691c14802ed529dd2c30bce9bda77b38f8cc751993138b7c1a886303a26
+    name: cluster-api-provider-agent-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: Dockerfile.rhtap
+        revision: c9e1cc7e5170dd33b931d9b5050047bbe8576008
+        url: https://github.com/openshift/cluster-api-provider-agent
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-210@sha256:f006e44ed97ffad0d0bf6437ed8f60467b2ef9e4fdf14bfa02ce3897384b055b
+    name: cluster-api-provider-aws-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: stolostron/Dockerfile.stolostron
+        revision: 61b4b150558453c2b66c5e24053930aaca494e83
+        url: https://github.com/stolostron/cluster-api-provider-aws
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-webhook-config-mce-210@sha256:4bdd058f1e3c430fb3eb35869c931528f9857867dc3526268fef2ecf90e2330d
+    name: cluster-api-webhook-config-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: mce-capi-webhook-config/Dockerfile
+        revision: 5e1d847edcae78a3dd9ca86b53cfa2b9838a0028
+        url: https://github.com/stolostron/cluster-api-installer
+    version: ""
+  - containerImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/clusterlifecycle-state-metrics-mce-210@sha256:ffd266cad8abbbea68bc0bbd3732a1686871f2c0a99b4b8157384966a49809f4
+    name: clusterlifecycle-state-metrics-mce-210
+    source:
+      git:
+        context: ./
+        dockerfileUrl: build/Dockerfile.rhtap
+        revision: 3bebb8fc7adf4f89dee215085270860f165dc09d
+        url: https://github.com/stolostron/clusterlifecycle-state-metrics
+    version: ""
 status:
   conditions:
-  - lastTransitionTime: "2026-06-03T09:31:48Z"
+  - lastTransitionTime: "2026-06-03T09:23:22Z"
     message: Snapshot integration status condition is finished since all testing pipelines
       completed
     reason: Finished
     status: "True"
     type: AppStudioIntegrationStatus
-  - lastTransitionTime: "2026-06-03T09:31:48Z"
+  - lastTransitionTime: "2026-06-03T09:23:22Z"
     message: All Integration Pipeline tests passed
     reason: Passed
     status: "True"
     type: AppStudioTestSucceeded
-  - lastTransitionTime: "2026-06-03T09:31:48Z"
+  - lastTransitionTime: "2026-06-03T09:23:22Z"
     message: The Snapshot was auto-released
     reason: AutoReleased
     status: "True"


### PR DESCRIPTION
Summary: Update snapshot for mce 2.10.3 (replace, generation 1)