### PR TITLE
fix: update CPE to 5.0

### DIFF
--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -21,4 +21,4 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       url="https://github.com/stolostron/mce-operator-bundle" \
       release="${BUNDLE_VERSION}" \
       distribution-scope="public" \
-      cpe="cpe:/a:redhat:multicluster_engine:2.17::el9"
+      cpe="cpe:/a:redhat:multicluster_engine:5.0::el9"


### PR DESCRIPTION
## Summary
- Update Dockerfile.in CPE from 2.17 to 5.0

Fixes incorrect CPE version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)