### PR TITLE
fix: update CPE and assisted installer refs

### DIFF
--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -21,4 +21,4 @@ LABEL com.redhat.component="multicluster-engine-operator-bundle-container" \
       url="https://github.com/stolostron/mce-operator-bundle" \
       release="${BUNDLE_VERSION}" \
       distribution-scope="public" \
-      cpe="cpe:/a:redhat:multicluster_engine:2.17::el9"
+      cpe="cpe:/a:redhat:multicluster_engine:5.1::el9"

--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -47,27 +47,27 @@
             {
               "image-key":          "assisted_image_service",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-image-service-rhel9:v2.17-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-image-service-rhel9:v5.0-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-rhel9:v2.17-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-rhel9:v5.0-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer_agent",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-agent-rhel9:v2.17-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-agent-rhel9:v5.0-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_installer_controller",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-controller-rhel9:v2.17-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-installer-controller-rhel9:v5.0-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "assisted_service_9",
               "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/assisted-service-9-rhel9:v2.17-latest",
+              "pre-pub-image-ref":  "quay.io/acm-d/assisted-service-9-rhel9:v5.0-latest",
               "as-pub-remote":      "registry.redhat.io/multicluster-engine"
             },{
               "image-key":          "ose_cluster_api_rhel9",


### PR DESCRIPTION
## Summary
- Update Dockerfile.in CPE from 2.17 to 5.1
- Update assisted installer refs from v2.17-latest to v5.0-latest

Fixes incorrect version references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)