### PR TITLE
fix: update workflow matrix to scan existing backplane branches

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -12,16 +12,17 @@ on:
       release_branch:
         description: 'Release branch to scan'
         required: false
-        default: 'backplane-2.17'
+        default: 'backplane-5.0'
         type: choice
         options:
+          - backplane-5.0
           - backplane-2.17
-          - backplane-2.16
-          - backplane-2.15
-          - backplane-2.14
-          - backplane-2.13
-          - backplane-2.12
           - backplane-2.11
+          - backplane-2.10
+          - backplane-2.9
+          - backplane-2.8
+          - backplane-2.7
+          - backplane-2.6
           - all
       severity:
         description: 'CVE severity levels to scan'
@@ -42,7 +43,7 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-2.17", "backplane-2.16", "backplane-2.15", "backplane-2.14", "backplane-2.13"]') || inputs.release_branch == 'all' && fromJSON('["backplane-2.17", "backplane-2.16", "backplane-2.15", "backplane-2.14", "backplane-2.13", "backplane-2.12", "backplane-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8"]') || inputs.release_branch == 'all' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7", "backplane-2.6"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:


### PR DESCRIPTION
## Summary
Fix workflow failures by scanning only branches that exist in repo

## Problem
Workflow scanning backplane-2.12 through 2.16 but these don't exist, causing git checkout failures

## Solution
Updated to scan existing branches only:
- Added backplane-5.0 (new)
- Kept 2.17, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6
- Removed non-existent 2.12-2.16

## Changes
- Scheduled: top 6 releases (5.0, 2.17, 2.11, 2.10, 2.9, 2.8)
- All option: 5.0 + n-5 releases (2.6-2.11, 2.17)