### PR TITLE
fix: revert quay.io secrets to ACMD names

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -146,8 +146,8 @@ jobs:
 
           # Log in to quay.io using podman (writes to correct location)
           # Use printf to avoid echo potentially exposing secrets in logs
-          printf '%s' "${{ secrets.QUAY_IO_MCED_RGY_PASSWORD }}" \
-            | podman login -u="${{ vars.QUAY_IO_MCED_RGY_USERNAME }}" --password-stdin quay.io
+          printf '%s' "${{ secrets.QUAY_IO_ACMD_RGY_PASSWORD }}" \
+            | podman login -u="${{ vars.QUAY_IO_ACMD_RGY_USERNAME }}" --password-stdin quay.io
 
           # Also login to other registries that images might come from
           printf '%s' "${{ secrets.REGISTRY_REDHAT_IO_RGY_PASSWORD }}" \


### PR DESCRIPTION
## Summary
Fix quay.io login failure by using correct secret names

## Problem
Login failing with "inappropriate ioctl for device" - secret QUAY_IO_MCED_RGY_PASSWORD doesn't exist

## Solution  
Revert to QUAY_IO_ACMD_RGY_* secrets - MCE repo shares ACM secrets