### PR TITLE
fix: search recursively for grype JSON files

### DIFF
--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -199,9 +199,9 @@ def main():
     # Find scan report
     scan_report_path = args.scan_report
     if not scan_report_path:
-        # Look for latest Grype JSON in reports dir
+        # Look for latest Grype JSON in reports dir (search recursively)
         reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.glob('*-grype.json'))
+        json_files = list(reports_path.rglob('*-grype.json'))
         if not json_files:
             console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
             sys.exit(1)


### PR DESCRIPTION
## Summary
Fix 'No Grype JSON reports found' error

## Problem
Script searches reports/ flat but scan creates nested reports/VERSION/json/ structure

## Solution
Use rglob() instead of glob() to search recursively

Same fix as ACM #3519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scan report discovery to recursively search through all nested directories for the latest report file, rather than only checking the top-level directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->