### PR TITLE
fix: rglob search, f-string syntax, and grype filename pattern

### DIFF
--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -1090,7 +1090,7 @@ def generate_release_tab_content(release, history, extras_metadata=None):
                 {''.join(external_rows)}
             </tbody>
         </table>
-        {'<button class="show-all-btn" onclick="toggleShowAll(\'' + tab_id + '\', \'external\')">Show All External (' + str(len(external_components)) + ' total)</button>' if len(external_components) > 15 else ''}
+        {f'<button class="show-all-btn" onclick="toggleShowAll({chr(39)}{tab_id}{chr(39)}, {chr(39)}external{chr(39)})">Show All External ({len(external_components)} total)</button>' if len(external_components) > 15 else ''}
 
         {generate_fixed_cves_section(latest_scan, tab_id)}
     </div>"""

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -201,7 +201,7 @@ def main():
     if not scan_report_path:
         # Look for latest Grype JSON in reports dir (search recursively)
         reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.rglob('*-grype.json'))
+        json_files = list(reports_path.rglob('*_grype.json'))
         if not json_files:
             console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
             sys.exit(1)


### PR DESCRIPTION
## Summary
Fix store_scan_results.py to find grype JSON files and Python 3.12+ syntax error

## Problems
1. Script searches flat `reports/` but scan creates nested `reports/VERSION/json/`
2. SyntaxError - backslash in f-string expression
3. Pattern `*-grype.json` doesn't match actual files `*_grype.json`

## Solutions
1. Use rglob() instead of glob() for recursive search
2. Replace escaped quotes with chr(39)
3. Fix pattern from dash to underscore

Same fixes as ACM stolostron/acm-operator-bundle#3522