### PR TITLE
fix: force add reports/trends/ despite gitignore

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -369,7 +369,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add reports/trends/
+          git add -f reports/trends/
 
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary
Fix aggregate-and-commit job git add failure

## Problem
`git add reports/trends/` fails - reports/ in .gitignore

## Solution  
Use `git add -f` to force add

Same fix as ACM #3525