### PR TITLE
fix: use wildcard pattern to find both release and backplane history files

### DIFF
--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -1384,8 +1384,8 @@ def main():
         console.print(f"[red]Trends directory not found: {trends_dir}[/red]")
         sys.exit(1)
 
-    # Find all history files
-    history_files = list(trends_dir.glob('release-*-history.json'))
+    # Find all history files (both release-* for ACM and backplane-* for MCE)
+    history_files = list(trends_dir.glob('*-history.json'))
 
     if not history_files:
         console.print("[yellow]No release history files found[/yellow]")


### PR DESCRIPTION
## Summary
Fix multi-release dashboard not generating for MCE

## Problem
Pattern `release-*-history.json` doesn't match MCE files `backplane-*-history.json`  
Script exits with "No release history files found" despite files existing

## Solution
Use `*-history.json` wildcard to match both ACM (release-) and MCE (backplane-) naming

## Testing
Run shows 8 backplane history files merged but dashboard not created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the multi-release dashboard generator to discover and include a broader range of historical releases and backplanes in generated dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->