### PR TITLE
Track exact version and extras metadata for CVE trends

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -302,6 +302,15 @@ jobs:
           retention-days: 90
         continue-on-error: true
 
+      - name: Upload extras metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extras-${{ env.RELEASE_BRANCH }}
+          path: extras/
+          retention-days: 90
+        continue-on-error: true
+
       - name: Check for critical CVEs
         run: |
           # Count critical CVEs and fail if threshold exceeded
@@ -344,7 +353,15 @@ jobs:
           path: downloaded-history/
           merge-multiple: false
 
-      - name: Merge history files
+      - name: Download all extras artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: extras-*
+          path: downloaded-extras/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Merge history and extras files
         run: |
           echo "Merging history files from artifacts..."
           mkdir -p reports/trends
@@ -358,6 +375,23 @@ jobs:
 
           ls -la reports/trends/
           echo "✓ History files merged"
+
+          # Merge extras from all releases (later releases overwrite earlier)
+          echo "Merging extras metadata from artifacts..."
+          mkdir -p extras
+
+          for extras_dir in downloaded-extras/extras-*/; do
+            if [ -d "$extras_dir" ]; then
+              cp "$extras_dir"*.json extras/ || true
+            fi
+          done
+
+          if [ -d "extras" ] && [ "$(ls -A extras)" ]; then
+            echo "✓ Extras metadata merged"
+            ls -la extras/
+          else
+            echo "⚠️  No extras metadata found (internal/external categorization unavailable)"
+          fi
 
       - name: Generate multi-release dashboard
         run: |

--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -12,17 +12,17 @@ on:
       release_branch:
         description: 'Release branch to scan'
         required: false
-        default: 'backplane-5.0'
+        default: 'release-5.0'
         type: choice
         options:
-          - backplane-5.0
-          - backplane-2.17
-          - backplane-2.11
-          - backplane-2.10
-          - backplane-2.9
-          - backplane-2.8
-          - backplane-2.7
-          - backplane-2.6
+          - release-5.0
+          - release-2.17
+          - release-2.16
+          - release-2.15
+          - release-2.14
+          - release-2.13
+          - release-2.12
+          - release-2.11
           - all
       severity:
         description: 'CVE severity levels to scan'
@@ -31,6 +31,11 @@ on:
         type: string
       auto_commit:
         description: 'Auto-commit results to main branch'
+        required: false
+        default: false
+        type: boolean
+      skip_slack:
+        description: 'Skip Slack notifications'
         required: false
         default: false
         type: boolean
@@ -43,13 +48,13 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8"]') || inputs.release_branch == 'all' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7", "backplane-2.6"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13"]') || inputs.release_branch == 'all' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13", "release-2.12", "release-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:
       # Use matrix value for scheduled runs, or workflow input for manual runs
       RELEASE_BRANCH: ${{ matrix.release_branch }}
-      MCE_VERSION: ${{ vars.MCE_VERSION || '' }}
+      ACM_VERSION: ${{ vars.ACM_VERSION || '' }}
       SCAN_SEVERITY: ${{ inputs.severity || vars.SCAN_SEVERITY || 'HIGH,CRITICAL' }}
 
     steps:
@@ -99,7 +104,7 @@ jobs:
           echo "🔍 CVE Scan Configuration"
           echo "========================="
           echo "Release Branch: ${{ env.RELEASE_BRANCH }}"
-          echo "MCE Version: ${{ env.MCE_VERSION || '(auto-detected from extras/*.json)' }}"
+          echo "ACM Version: ${{ env.ACM_VERSION || '(auto-detected from extras/*.json)' }}"
           echo "Severity Filter: ${{ env.SCAN_SEVERITY }}"
           echo "Workflow Branch: ${{ github.ref_name }}"
 
@@ -224,10 +229,10 @@ jobs:
 
       - name: Run CVE scan with JSON output
         run: |
-          echo "Scanning MCE ${{ env.MCE_VERSION }} images for CVEs (${{ env.SCAN_SEVERITY }} severity)..."
+          echo "Scanning ACM ${{ env.ACM_VERSION }} images for CVEs (${{ env.SCAN_SEVERITY }} severity)..."
           make scan-cves-json-icsp
         env:
-          MCE_VERSION: ${{ env.MCE_VERSION }}
+          ACM_VERSION: ${{ env.ACM_VERSION }}
           ICSP_CONFIG: icsp-config.json
           EXTRAS_DIR: extras
           REPORTS_DIR: reports
@@ -241,7 +246,7 @@ jobs:
         continue-on-error: true
 
       - name: Send summary to Slack
-        if: always()
+        if: always() && !inputs.skip_slack
         run: |
           echo "Sending CVE report to Slack..."
           # Use bot token if available (threaded mode), otherwise webhook
@@ -259,7 +264,7 @@ jobs:
 
           make slack-cve-report
         env:
-          MCE_VERSION: ${{ env.MCE_VERSION }}
+          ACM_VERSION: ${{ env.ACM_VERSION }}
           REPORTS_DIR: reports
           EXTRAS_DIR: extras
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CVE_WEBHOOK_URL }}

--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -19,7 +19,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MCE CVE Trends - All Releases</title>
+    <title>ACM CVE Trends - All Releases</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <style>
         * {{
@@ -871,10 +871,16 @@ def get_version_from_reports(release):
     return matching[-1]
 
 
-def generate_tab_button(release, is_active=False):
+def generate_tab_button(release, history=None, is_active=False):
     """Generate tab button HTML"""
     tab_id = release.replace('.', '').replace('-', '')  # release-2.17 -> release217
-    display_name = get_version_from_reports(release)
+
+    # Try to get version from history first, fallback to reports dir
+    if history and history.get('version'):
+        display_name = history['version']
+    else:
+        display_name = get_version_from_reports(release)
+
     active_class = ' active' if is_active else ''
     return f'<button class="tab{active_class}" onclick="openTab(event, \'{tab_id}\')">{display_name}</button>'
 
@@ -1384,8 +1390,8 @@ def main():
         console.print(f"[red]Trends directory not found: {trends_dir}[/red]")
         sys.exit(1)
 
-    # Find all history files (both release-* for ACM and backplane-* for MCE)
-    history_files = list(trends_dir.glob('*-history.json'))
+    # Find all history files
+    history_files = list(trends_dir.glob('release-*-history.json'))
 
     if not history_files:
         console.print("[yellow]No release history files found[/yellow]")
@@ -1414,7 +1420,7 @@ def main():
         sys.exit(0)
 
     # Generate HTML components
-    tab_buttons = '\n'.join([generate_tab_button(rel) for rel in sorted(releases.keys())])
+    tab_buttons = '\n'.join([generate_tab_button(rel, hist) for rel, hist in sorted(releases.items())])
     tab_contents = '\n'.join([generate_release_tab_content(rel, hist, extras_metadata) for rel, hist in sorted(releases.items())])
     comparison_cards = '\n'.join([generate_comparison_card(rel, hist) for rel, hist in sorted(releases.items())])
 
@@ -1443,6 +1449,7 @@ def main():
     # Generate final HTML
     html = HTML_TEMPLATE.format(
         timestamp=datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'),
+        tab_buttons=tab_buttons,
         tab_contents=tab_contents,
         comparison_cards=comparison_cards,
         chart_data_js=compare_data_js,

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -37,43 +37,66 @@ def load_history(history_file):
         sys.exit(1)
 
 
-def extract_scan_summary(scan_report):
-    """Extract summary statistics from Grype JSON report"""
-    matches = scan_report.get('matches', [])
+def extract_image_key_from_filename(filepath):
+    """Extract image key from grype JSON filename
 
-    # Count by severity
-    severity_counts = {
-        'CRITICAL': 0,
-        'HIGH': 0,
-        'MEDIUM': 0,
-        'LOW': 0,
-        'NEGLIGIBLE': 0,
-        'UNKNOWN': 0
-    }
+    Example: 2.17.0_klusterlet_addon_controller_grype.json -> klusterlet_addon_controller
+    """
+    filename = Path(filepath).name
+    # Remove version prefix and _grype.json suffix
+    # Pattern: {version}_{image_key}_grype.json
+    parts = filename.replace('_grype.json', '').split('_')
+    # First part is version (e.g., 2.17.0), rest is image key
+    if len(parts) > 1:
+        return '_'.join(parts[1:])
+    return 'unknown'
 
-    # Track unique CVEs and components
-    cve_set = set()
-    component_breakdown = {}
-    cve_details = []
 
-    for match in matches:
-        vuln = match.get('vulnerability', {})
-        artifact = match.get('artifact', {})
+def extract_scan_summary_from_all(reports_dir):
+    """Extract summary statistics from all Grype JSON reports, grouped by image
 
-        cve_id = vuln.get('id', 'UNKNOWN')
-        severity = vuln.get('severity', 'UNKNOWN').upper()
-        component = artifact.get('name', 'unknown')
+    Args:
+        reports_dir: Path to reports directory
 
-        # Count by severity
-        if severity in severity_counts:
-            severity_counts[severity] += 1
+    Returns:
+        dict with overall stats and per-image component_breakdown
+    """
+    reports_path = Path(reports_dir)
+    json_files = list(reports_path.rglob('*_grype.json'))
 
-        # Track unique CVEs
-        cve_set.add(cve_id)
+    if not json_files:
+        console.print(f"[yellow]Warning: No Grype JSON files found in {reports_dir}[/yellow]")
+        return {
+            'total_cves': 0,
+            'total_matches': 0,
+            'by_severity': {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0},
+            'component_breakdown': {},
+            'cve_details': []
+        }
 
-        # Track per-component breakdown
-        if component not in component_breakdown:
-            component_breakdown[component] = {
+    # Global counters
+    severity_counts = {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0}
+    global_cve_set = set()
+    total_matches = 0
+    component_breakdown = {}  # keyed by image_key
+    all_cve_details = []
+
+    for json_file in json_files:
+        image_key = extract_image_key_from_filename(json_file)
+
+        try:
+            with open(json_file, 'r') as f:
+                scan_report = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            console.print(f"[yellow]Warning: Could not read {json_file}: {e}[/yellow]")
+            continue
+
+        matches = scan_report.get('matches', [])
+        total_matches += len(matches)
+
+        # Initialize image entry
+        if image_key not in component_breakdown:
+            component_breakdown[image_key] = {
                 'CRITICAL': 0,
                 'HIGH': 0,
                 'MEDIUM': 0,
@@ -81,25 +104,42 @@ def extract_scan_summary(scan_report):
                 'total': 0
             }
 
-        if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
-            component_breakdown[component][severity] += 1
-        component_breakdown[component]['total'] += 1
+        for match in matches:
+            vuln = match.get('vulnerability', {})
+            artifact = match.get('artifact', {})
 
-        # Store CVE details for new/fixed detection
-        cve_details.append({
-            'cve_id': cve_id,
-            'severity': severity,
-            'component': component,
-            'fixed_versions': vuln.get('fix', {}).get('versions', []),
-            'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
-        })
+            cve_id = vuln.get('id', 'UNKNOWN')
+            severity = vuln.get('severity', 'UNKNOWN').upper()
+            package_name = artifact.get('name', 'unknown')
+
+            # Count by severity globally
+            if severity in severity_counts:
+                severity_counts[severity] += 1
+
+            # Track unique CVEs globally
+            global_cve_set.add(cve_id)
+
+            # Count by severity per image
+            if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+                component_breakdown[image_key][severity] += 1
+            component_breakdown[image_key]['total'] += 1
+
+            # Store CVE details with image context
+            all_cve_details.append({
+                'cve_id': cve_id,
+                'severity': severity,
+                'component': image_key,  # Now this is the image, not the package
+                'package': package_name,
+                'fixed_versions': vuln.get('fix', {}).get('versions', []),
+                'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
+            })
 
     return {
-        'total_cves': len(cve_set),
-        'total_matches': len(matches),
+        'total_cves': len(global_cve_set),
+        'total_matches': total_matches,
         'by_severity': severity_counts,
         'component_breakdown': component_breakdown,
-        'cve_details': cve_details
+        'cve_details': all_cve_details
     }
 
 
@@ -210,34 +250,9 @@ def main():
     if full_version:
         console.print(f"[cyan]Version: {full_version}[/cyan]")
 
-    # Find scan report
-    scan_report_path = args.scan_report
-    if not scan_report_path:
-        # Look for latest Grype JSON in reports dir (search recursively)
-        reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.rglob('*_grype.json'))
-        if not json_files:
-            console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
-            sys.exit(1)
-        scan_report_path = max(json_files, key=lambda p: p.stat().st_mtime)
-
-    scan_report_path = Path(scan_report_path)
-    if not scan_report_path.exists():
-        console.print(f"[red]Scan report not found: {scan_report_path}[/red]")
-        sys.exit(1)
-
-    console.print(f"[cyan]Loading scan report: {scan_report_path}[/cyan]")
-
-    # Load scan report
-    try:
-        with open(scan_report_path, 'r') as f:
-            scan_report = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        console.print(f"[red]Error loading scan report: {e}[/red]")
-        sys.exit(1)
-
-    # Extract summary
-    summary = extract_scan_summary(scan_report)
+    # Extract summary from all Grype JSON files
+    console.print(f"[cyan]Processing all Grype scan results in {args.reports_dir}[/cyan]")
+    summary = extract_scan_summary_from_all(args.reports_dir)
 
     # Load or create history
     trends_dir = Path(args.reports_dir) / 'trends'
@@ -261,7 +276,6 @@ def main():
     # Create scan record
     scan_record = {
         'timestamp': datetime.now(timezone.utc).isoformat() + 'Z',
-        'scan_report_path': str(scan_report_path),
         'github_run_id': args.github_run_id or os.environ.get('GITHUB_RUN_ID'),
         'summary': {
             'total_cves': summary['total_cves'],

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -18,6 +18,7 @@ def load_history(history_file):
     if not history_file.exists():
         return {
             "release": None,
+            "version": None,
             "scans": [],
             "metadata": {
                 "created": datetime.now(timezone.utc).isoformat() + "Z",
@@ -136,19 +137,26 @@ def detect_changes(current_scan, previous_scan):
 
 
 def detect_release_from_extras(extras_dir):
-    """Auto-detect release version from extras directory"""
+    """Auto-detect release version from extras directory
+
+    Returns:
+        tuple: (release_name, full_version) e.g., ('release-2.17', '2.17.0')
+    """
     extras_path = Path(extras_dir)
     if not extras_path.exists():
-        return None
+        return None, None
 
     # Look for version pattern in JSON filenames (e.g., 2.17.0.json)
     for json_file in extras_path.glob('*.json'):
         name = json_file.stem
         parts = name.split('.')
-        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
-            return f"release-{parts[0]}.{parts[1]}"
+        if len(parts) >= 3 and parts[0].isdigit() and parts[1].isdigit():
+            # Return both release-X.Y and full X.Y.Z
+            release_name = f"release-{parts[0]}.{parts[1]}"
+            full_version = name  # e.g., "2.17.0"
+            return release_name, full_version
 
-    return None
+    return None, None
 
 
 def prune_old_scans(history, retention_weeks=None, max_scans=None):
@@ -188,13 +196,19 @@ def main():
 
     # Detect release if not provided
     release = args.release
+    full_version = None
     if not release:
-        release = detect_release_from_extras(args.extras_dir)
+        release, full_version = detect_release_from_extras(args.extras_dir)
         if not release:
             console.print("[red]Could not auto-detect release. Use --release flag[/red]")
             sys.exit(1)
+    else:
+        # Manual release specified, try to get version from extras
+        _, full_version = detect_release_from_extras(args.extras_dir)
 
     console.print(f"[cyan]Storing scan results for {release}[/cyan]")
+    if full_version:
+        console.print(f"[cyan]Version: {full_version}[/cyan]")
 
     # Find scan report
     scan_report_path = args.scan_report
@@ -232,9 +246,11 @@ def main():
     history_file = trends_dir / f"{release}-history.json"
     history = load_history(history_file)
 
-    # Set release name if new history
+    # Set release name and version if new history
     if not history.get('release'):
         history['release'] = release
+    if full_version and not history.get('version'):
+        history['version'] = full_version
 
     # Get previous scan for comparison
     previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -18,6 +18,7 @@ def load_history(history_file):
     if not history_file.exists():
         return {
             "release": None,
+            "version": None,
             "scans": [],
             "metadata": {
                 "created": datetime.now(timezone.utc).isoformat() + "Z",
@@ -36,43 +37,66 @@ def load_history(history_file):
         sys.exit(1)
 
 
-def extract_scan_summary(scan_report):
-    """Extract summary statistics from Grype JSON report"""
-    matches = scan_report.get('matches', [])
+def extract_image_key_from_filename(filepath):
+    """Extract image key from grype JSON filename
 
-    # Count by severity
-    severity_counts = {
-        'CRITICAL': 0,
-        'HIGH': 0,
-        'MEDIUM': 0,
-        'LOW': 0,
-        'NEGLIGIBLE': 0,
-        'UNKNOWN': 0
-    }
+    Example: 2.17.0_klusterlet_addon_controller_grype.json -> klusterlet_addon_controller
+    """
+    filename = Path(filepath).name
+    # Remove version prefix and _grype.json suffix
+    # Pattern: {version}_{image_key}_grype.json
+    parts = filename.replace('_grype.json', '').split('_')
+    # First part is version (e.g., 2.17.0), rest is image key
+    if len(parts) > 1:
+        return '_'.join(parts[1:])
+    return 'unknown'
 
-    # Track unique CVEs and components
-    cve_set = set()
-    component_breakdown = {}
-    cve_details = []
 
-    for match in matches:
-        vuln = match.get('vulnerability', {})
-        artifact = match.get('artifact', {})
+def extract_scan_summary_from_all(reports_dir):
+    """Extract summary statistics from all Grype JSON reports, grouped by image
 
-        cve_id = vuln.get('id', 'UNKNOWN')
-        severity = vuln.get('severity', 'UNKNOWN').upper()
-        component = artifact.get('name', 'unknown')
+    Args:
+        reports_dir: Path to reports directory
 
-        # Count by severity
-        if severity in severity_counts:
-            severity_counts[severity] += 1
+    Returns:
+        dict with overall stats and per-image component_breakdown
+    """
+    reports_path = Path(reports_dir)
+    json_files = list(reports_path.rglob('*_grype.json'))
 
-        # Track unique CVEs
-        cve_set.add(cve_id)
+    if not json_files:
+        console.print(f"[yellow]Warning: No Grype JSON files found in {reports_dir}[/yellow]")
+        return {
+            'total_cves': 0,
+            'total_matches': 0,
+            'by_severity': {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0},
+            'component_breakdown': {},
+            'cve_details': []
+        }
 
-        # Track per-component breakdown
-        if component not in component_breakdown:
-            component_breakdown[component] = {
+    # Global counters
+    severity_counts = {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0}
+    global_cve_set = set()
+    total_matches = 0
+    component_breakdown = {}  # keyed by image_key
+    all_cve_details = []
+
+    for json_file in json_files:
+        image_key = extract_image_key_from_filename(json_file)
+
+        try:
+            with open(json_file, 'r') as f:
+                scan_report = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            console.print(f"[yellow]Warning: Could not read {json_file}: {e}[/yellow]")
+            continue
+
+        matches = scan_report.get('matches', [])
+        total_matches += len(matches)
+
+        # Initialize image entry
+        if image_key not in component_breakdown:
+            component_breakdown[image_key] = {
                 'CRITICAL': 0,
                 'HIGH': 0,
                 'MEDIUM': 0,
@@ -80,25 +104,42 @@ def extract_scan_summary(scan_report):
                 'total': 0
             }
 
-        if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
-            component_breakdown[component][severity] += 1
-        component_breakdown[component]['total'] += 1
+        for match in matches:
+            vuln = match.get('vulnerability', {})
+            artifact = match.get('artifact', {})
 
-        # Store CVE details for new/fixed detection
-        cve_details.append({
-            'cve_id': cve_id,
-            'severity': severity,
-            'component': component,
-            'fixed_versions': vuln.get('fix', {}).get('versions', []),
-            'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
-        })
+            cve_id = vuln.get('id', 'UNKNOWN')
+            severity = vuln.get('severity', 'UNKNOWN').upper()
+            package_name = artifact.get('name', 'unknown')
+
+            # Count by severity globally
+            if severity in severity_counts:
+                severity_counts[severity] += 1
+
+            # Track unique CVEs globally
+            global_cve_set.add(cve_id)
+
+            # Count by severity per image
+            if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+                component_breakdown[image_key][severity] += 1
+            component_breakdown[image_key]['total'] += 1
+
+            # Store CVE details with image context
+            all_cve_details.append({
+                'cve_id': cve_id,
+                'severity': severity,
+                'component': image_key,  # Now this is the image, not the package
+                'package': package_name,
+                'fixed_versions': vuln.get('fix', {}).get('versions', []),
+                'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
+            })
 
     return {
-        'total_cves': len(cve_set),
-        'total_matches': len(matches),
+        'total_cves': len(global_cve_set),
+        'total_matches': total_matches,
         'by_severity': severity_counts,
         'component_breakdown': component_breakdown,
-        'cve_details': cve_details
+        'cve_details': all_cve_details
     }
 
 
@@ -136,19 +177,26 @@ def detect_changes(current_scan, previous_scan):
 
 
 def detect_release_from_extras(extras_dir):
-    """Auto-detect release version from extras directory"""
+    """Auto-detect release version from extras directory
+
+    Returns:
+        tuple: (release_name, full_version) e.g., ('release-2.17', '2.17.0')
+    """
     extras_path = Path(extras_dir)
     if not extras_path.exists():
-        return None
+        return None, None
 
     # Look for version pattern in JSON filenames (e.g., 2.17.0.json)
     for json_file in extras_path.glob('*.json'):
         name = json_file.stem
         parts = name.split('.')
-        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
-            return f"release-{parts[0]}.{parts[1]}"
+        if len(parts) >= 3 and parts[0].isdigit() and parts[1].isdigit():
+            # Return both release-X.Y and full X.Y.Z
+            release_name = f"release-{parts[0]}.{parts[1]}"
+            full_version = name  # e.g., "2.17.0"
+            return release_name, full_version
 
-    return None
+    return None, None
 
 
 def prune_old_scans(history, retention_weeks=None, max_scans=None):
@@ -188,42 +236,23 @@ def main():
 
     # Detect release if not provided
     release = args.release
+    full_version = None
     if not release:
-        release = detect_release_from_extras(args.extras_dir)
+        release, full_version = detect_release_from_extras(args.extras_dir)
         if not release:
             console.print("[red]Could not auto-detect release. Use --release flag[/red]")
             sys.exit(1)
+    else:
+        # Manual release specified, try to get version from extras
+        _, full_version = detect_release_from_extras(args.extras_dir)
 
     console.print(f"[cyan]Storing scan results for {release}[/cyan]")
+    if full_version:
+        console.print(f"[cyan]Version: {full_version}[/cyan]")
 
-    # Find scan report
-    scan_report_path = args.scan_report
-    if not scan_report_path:
-        # Look for latest Grype JSON in reports dir (search recursively)
-        reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.rglob('*_grype.json'))
-        if not json_files:
-            console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
-            sys.exit(1)
-        scan_report_path = max(json_files, key=lambda p: p.stat().st_mtime)
-
-    scan_report_path = Path(scan_report_path)
-    if not scan_report_path.exists():
-        console.print(f"[red]Scan report not found: {scan_report_path}[/red]")
-        sys.exit(1)
-
-    console.print(f"[cyan]Loading scan report: {scan_report_path}[/cyan]")
-
-    # Load scan report
-    try:
-        with open(scan_report_path, 'r') as f:
-            scan_report = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        console.print(f"[red]Error loading scan report: {e}[/red]")
-        sys.exit(1)
-
-    # Extract summary
-    summary = extract_scan_summary(scan_report)
+    # Extract summary from all Grype JSON files
+    console.print(f"[cyan]Processing all Grype scan results in {args.reports_dir}[/cyan]")
+    summary = extract_scan_summary_from_all(args.reports_dir)
 
     # Load or create history
     trends_dir = Path(args.reports_dir) / 'trends'
@@ -232,9 +261,11 @@ def main():
     history_file = trends_dir / f"{release}-history.json"
     history = load_history(history_file)
 
-    # Set release name if new history
+    # Set release name and version
     if not history.get('release'):
         history['release'] = release
+    if full_version:
+        history['version'] = full_version  # Update every scan to track patch versions
 
     # Get previous scan for comparison
     previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None
@@ -245,13 +276,13 @@ def main():
     # Create scan record
     scan_record = {
         'timestamp': datetime.now(timezone.utc).isoformat() + 'Z',
-        'scan_report_path': str(scan_report_path),
         'github_run_id': args.github_run_id or os.environ.get('GITHUB_RUN_ID'),
         'summary': {
             'total_cves': summary['total_cves'],
             'total_matches': summary['total_matches'],
             'by_severity': summary['by_severity'],
-            'component_breakdown': summary['component_breakdown']
+            'component_breakdown': summary['component_breakdown'],
+            'cve_details': summary['cve_details']
         },
         'new_cves': new_cves,
         'fixed_cves': fixed_cves


### PR DESCRIPTION
## Summary
- Store full version (x.y.z) in history metadata from extras filename
- Upload extras/ as artifact in scan job for git_url lookup
- Download and merge extras in aggregate job for internal/external categorization  
- Display exact version in dashboard tabs from history instead of reports dir

## Fixes
- All components showing as external in multi-release dashboard (no git_url available)
- Tab labels showing x.y instead of x.y.z

## Changes
**scripts/store_scan_results.py:**
- Modified `detect_release_from_extras()` to return both release name and full version
- Added `version` field to history metadata structure
- Store detected version from extras/x.y.z.json filename

**scripts/generate_multi_release_dashboard.py:**
- Modified `generate_tab_button()` to accept history and read version from it
- Tab labels now show exact x.y.z from history instead of falling back to x.y

**.github/workflows/weekly-cve-scan.yml:**
- Added step to upload extras/ as artifact after each scan job
- Added step in aggregate job to download all extras-* artifacts
- Merge extras/ temporarily for dashboard generation (not committed)

## Test Plan
- [x] Manual trigger workflow with auto_commit=true
- [ ] Verify tabs show x.y.z versions
- [ ] Verify internal components appear (have git_url from extras)
- [ ] Verify extras/ not committed to main (only reports/trends/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow: optional "skip Slack" toggle to suppress Slack summaries.
  * Scan workflow now uploads per-release metadata and aggregates extras into a merged set for multi-release dashboards.
  * CVE summarization now aggregates across all scan reports, preserving per-image context and detailed CVE entries.

* **Updates**
  * Branding: dashboard title updated to reflect ACM naming.
  * Dashboard tabs prefer version info from scan history when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->