### PR TITLE
Fix CVE component grouping and version tracking

### DIFF
--- a/.claude/skills/cve-to-jira/SKILL.md
+++ b/.claude/skills/cve-to-jira/SKILL.md
@@ -1,0 +1,446 @@
+---
+name: cve-to-jira
+description: >
+  Create JIRA issues from CVE scan reports. Scans Grype JSON reports for HIGH/CRITICAL 
+  vulnerabilities across release branches, checks for existing issues, and auto-creates 
+  component-scoped JIRA tickets with version impact tables. Use when user asks to "create 
+  CVE issues", "track CVEs in JIRA", "file CVE tickets", or "generate security issues". 
+  Supports dry-run mode for preview. Focus on MCE release branches (e.g., 2.9) branches by default.
+user-invocable: true
+---
+
+# CVE-to-JIRA Issue Creator
+
+Auto-create JIRA issues from CVE scan reports with duplicate detection.
+
+## When to Use
+
+Trigger when user wants to:
+- Create JIRA issues from CVE scans
+- Track security vulnerabilities in JIRA
+- File CVE tickets for team remediation
+- Generate security issue reports
+
+## Prerequisites
+
+1. **JIRA Credentials**: Must source credentials first
+   ```bash
+   source ~/.claude/jira-credentials.sh
+   ```
+
+2. **CVE Reports**: Reports must exist in `reports/` directory
+   - Run CVE scan: `make scan-cves-json-icsp`
+   - Or use existing reports from GitHub Actions artifacts
+
+3. **Component Registry** (optional): For automatic team assignment
+   - Located at `~/dislbenn/acm-config/product/component-registry.yaml`
+   - Maps components to teams/squads
+   - Auto-detected, falls back to "Installer" if not found
+
+**Note**: MCE uses the ACM JIRA project but with MCE version prefix (e.g., "MCE 2.7.2" instead of "ACM 2.15.2")
+
+## Arguments
+
+Parse from `$ARGUMENTS`:
+
+- **Empty/no args**: Scan all available branches, create Epic and linked issues (prompts for sprint)
+- **`--dry-run`**: Preview issues without creating. Skips Epic creation/update and all JIRA writes (recommended first run)
+- **`--branches X,Y,Z`**: Limit to specific branches (e.g., `--branches 2.17,2.15`)
+- **`--sprint LABEL`**: Sprint label for Epic (e.g., `--sprint Sprint3`). Prompts if not provided.
+- **`--component NAME`**: Process single component only (for testing)
+- **`--no-epic`**: Create standalone issues without Epic parent
+- **`--verbose`**: Show detailed output including API calls
+- **`--reports-dir PATH`**: Override reports directory (default: `reports`)
+
+## How It Works
+
+1. **Load credentials** from `~/.claude/jira-credentials.sh`
+2. **Scan CVE reports** from `reports/{version}/json/{version}_{component}_grype.json`
+3. **Load component registry** (if available)
+   - Maps component names to owning teams
+   - Example: `multiclusterhub_operator` → Install team, `cert_policy_controller` → GRC
+
+4. **Create or Update Epic** (unless `--no-epic` or `--dry-run`)
+   - **Search for existing Epic** by sprint label first
+   - **If found**: Update summary with new date, refresh description with latest stats
+   - **If not found**: Create new Epic
+   - Epic name: `CVE Remediation - {sprint} ({date})` (e.g., "CVE Remediation - Sprint3 (2026-05-06)")
+   - Epic description: Sprint label, last scanned date, versions scanned, summary stats
+   - Component: Installer (default)
+   - Labels: cve, security, automated, cve-scanner
+   - Prompts for sprint label if `--sprint` not provided
+
+5. **For each component**:
+   - Aggregate CVEs across all requested versions
+   - Build version impact table showing which releases affected
+   - Look up owning team from component registry
+   - **Search JIRA** for existing issue via JQL:
+     ```
+     project = ACM AND summary ~ "{component_name}" AND labels in (cve)
+     ```
+   - **If found and closed**: Skip completely (respects team decision - won't reopen)
+   - **If found and open**:
+     - **If all CVEs fixed** (no versions affected): Auto-close issue with comment
+     - **Otherwise, smart update**:
+       - **Update Summary** with current CVE counts (e.g., "2 HIGH" → "1 CRITICAL, 3 HIGH")
+       - **Update Priority** if severity changed (Major → Critical when CRITICAL CVEs found)
+       - **Update Affects Version/s** if changed (add new versions, remove fixed versions)
+       - **Update Labels** if fixability changed (all-fixable → partially-fixable)
+       - **Regenerate description** with updated version impact table (adds new version columns)
+       - **Add comment** documenting all changes (only if actual changes made)
+       - **Re-link to current sprint Epic** (moves from old Epic to new)
+   - **If not found**: Create new issue with:
+     - Issue Type: Vulnerability (falls back to Bug if Vulnerability unavailable)
+     - Summary: `[{team}] {component} - X CRITICAL, Y HIGH CVEs`
+     - Description: Wiki markup table with version impact
+     - Priority: Critical (if CRITICAL CVEs), Major (if HIGH only)
+     - Component: {team} (from registry, defaults to "Installer")
+     - Labels: cve, security, automated, cve-scanner
+     - Activity Type: Security & Compliance
+     - Affects Version/s: List of impacted releases
+     - **Epic Link**: Link to current sprint Epic
+
+6. **Output summary** of created/re-linked/failed issues and Epic key
+
+## Issue Format
+
+**Summary Example:**
+```
+[Install] multiclusterhub_operator - 2 CRITICAL, 4 HIGH CVEs
+[GRC] cert_policy_controller - 6 HIGH CVEs
+```
+(Team prefix comes from component registry)
+
+**Description Structure:**
+- CVE summary (counts, fixability ratio)
+- Version impact table (which releases affected)
+- CVE details (package, fix availability, NVD links)
+- Remediation recommendations
+
+## Implementation
+
+The skill runs as a Python module:
+
+```bash
+cd .claude/skills/cve-to-jira
+source ~/.claude/jira-credentials.sh
+python3 -m scripts.cli $ARGUMENTS
+```
+
+**Workflow:**
+
+1. Verify JIRA connection
+2. Parse arguments to determine:
+   - Versions to scan
+   - Component filter (if any)
+   - Dry-run vs live mode
+3. Scan reports directory and parse Grype JSON
+4. Group CVEs by component
+5. For each component:
+   - Check for existing JIRA issue
+   - Create new issue if not found (or preview if dry-run)
+6. Print summary table
+
+## Examples
+
+### Preview all available branches
+```
+/cve-to-jira --dry-run
+```
+
+Shows what Epic + issues would be created for all available branches.
+
+### Create Epic and issues for all branches
+```
+/cve-to-jira --sprint Sprint3
+```
+
+Creates Epic "CVE Remediation - Sprint3 (2026-05-06)" + linked JIRA issues for all available release branches.
+
+**Re-running same sprint:** Updates existing Epic title with new scan date.
+
+**Without `--sprint` flag:** Prompts interactively for sprint label.
+
+### Create issues for specific branches only
+```
+/cve-to-jira --branches 2.17,2.15
+```
+
+Limits scan to releases 2.17 and 2.15 only.
+
+### Test single component
+```
+/cve-to-jira --component multiclusterhub_operator --dry-run
+```
+
+Preview issue for one component only.
+
+### Create standalone issues without Epic
+```
+/cve-to-jira --no-epic
+```
+
+Creates component issues without parent Epic (flat structure).
+
+## Output
+
+**Console output includes:**
+- Processing progress with spinner
+- Summary of created/skipped/failed issues
+- Table of created issues with links
+- Preview of issue content (dry-run mode)
+- Error messages for failures
+
+**Example (first run):**
+```
+CVE-to-JIRA Issue Creator
+Mode: LIVE MODE
+
+Found 6 versions: 2.18.0, 2.17.0, 2.16.0, 2.15.2, 2.14.3, 2.11.10
+✓ JIRA connection OK (dbennett@redhat.com)
+
+Analyzing CVE reports...
+✓ Found 42 components with CVEs
+✓ Component registry loaded
+
+Creating CVE remediation Epic for Sprint3...
+✓ Created Epic: ACM-12345 (Sprint3, 2026-05-06)
+
+Processing 42 components... ━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
+```
+
+**Example (Sprint4 - new sprint):**
+```
+CVE-to-JIRA Issue Creator
+Mode: LIVE MODE
+
+Found 6 versions: 2.18.0, 2.17.0, 2.16.0, 2.15.2, 2.14.3, 2.11.10
+✓ JIRA connection OK (dbennett@redhat.com)
+
+Analyzing CVE reports...
+✓ Found 42 components with CVEs
+✓ Component registry loaded
+
+Creating CVE remediation Epic for Sprint4...
+✓ Created Epic: ACM-12400 (Sprint4, 2026-05-20)
+
+Processing 42 components... ━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
+  ↪ multiclusterhub_operator: Re-linked ACM-12346 to Epic
+  ↪ cert_policy_controller: Re-linked ACM-12347 to Epic
+  ✓ new_component: Created ACM-12401
+
+Summary
+=============================================================
+Created: 3 new issues
+Re-linked: 39 existing issues
+Errors: 0 components
+Total processed: 42 components
+Epic: ACM-12400 (42 issues linked)
+
+Created Issues:
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━┓
+┃ Component                  ┃ Issue     ┃ CVEs ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━┩
+│ new_component              │ ACM-12401 │    5 │
+│ another_new_component      │ ACM-12402 │    3 │
+│ third_new_component        │ ACM-12403 │    2 │
+└────────────────────────────┴───────────┴──────┘
+
+✓ Successfully created 3 and re-linked 39 issues
+```
+
+**Example (scanning additional versions - version updates):**
+```
+CVE-to-JIRA Issue Creator
+Mode: LIVE MODE
+
+Found 3 versions: 2.17.0, 2.15.2, 2.13.2
+✓ JIRA connection OK (dbennett@redhat.com)
+
+Analyzing CVE reports...
+✓ Found 38 components with CVEs
+✓ Component registry loaded
+
+Updating CVE remediation Epic for Sprint3...
+✓ Updated Epic: ACM-12345 (Sprint3, 2026-05-06)
+
+Processing 38 components... ━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
+  ↻ multiclusterhub_operator: Updated ACM-12346 versions
+  ↪ cert_policy_controller: Re-linked ACM-12347
+  ⊗ deprecated_component: Issue ACM-12300 closed (Won't Do) - skipping
+  ✓ new_component: Created ACM-12401
+
+Summary
+=============================================================
+Created: 1 new issue
+Re-linked: 36 existing issues (5 with version updates)
+Skipped: 1 closed issue
+Total processed: 38 components
+Epic: ACM-12345 (37 issues linked)
+
+JIRA comment added to updated issues:
+  "CVE scan update:
+   - Added versions: 2.13.2
+   - Priority changed: Major → Critical
+   - Fixability changed: all-fixable → partially-fixable
+   - Total CVEs: 2 CRITICAL, 4 HIGH
+   - Summary and description refreshed"
+```
+
+**Example (CVE fixed in newer release):**
+```
+Scan 2.17, 2.15: both have CVE-2026-4424
+  → Creates ACM-12500 with Affects Version/s: [2.17.0, 2.15.2]
+
+Team updates base image in 2.17 branch, CVE fixed
+
+Scan 2.17, 2.15 again: only 2.15 still vulnerable
+  ↻ component: Updated ACM-12500
+  Comment: "CVE scan update:
+            - Removed versions: 2.17.0
+            - Total CVEs: 0 CRITICAL, 1 HIGH
+            - Summary and description refreshed"
+  Affects Version/s now: [2.15.2]
+  Priority: Major → Major (no CRITICAL)
+```
+
+**Example (all CVEs fixed - auto-close):**
+```
+Scan 2.17, 2.15: both have CVE-2026-4424
+  → ACM-12500 open with Affects Version/s: [2.17.0, 2.15.2]
+
+Team updates base images in both branches, CVE fixed everywhere
+
+Scan 2.17, 2.15 again: no vulnerabilities
+  ✓ component: Closed ACM-12500 (all CVEs fixed)
+  Comment: "CVE scan update:
+            - All CVEs resolved across all scanned versions
+            - Automatically closing issue
+            - Reopen manually if CVEs reappear"
+  Status: Closed
+  Affects Version/s: [] (empty)
+```
+
+
+## Re-running Behavior
+
+**Same sprint, different day or scanning additional versions:**
+- Finds existing Epic by sprint label
+- Updates Epic title with new date: `Sprint3 (2026-05-06)` → `Sprint3 (2026-05-07)`
+- Updates description with latest stats (component count, CVE totals)
+- **For existing open issues** - intelligently updates only what changed:
+  - **Summary**: Updates CVE counts if changed (e.g., "2 HIGH" → "1 CRITICAL, 3 HIGH")
+  - **Priority**: Escalates if CRITICAL found (Major → Critical), or demotes if fixed
+  - **Affects Version/s**: Adds new versions (2.13.2), removes fixed versions
+  - **Labels**: Updates fixability (all-fixable → partially-fixable when new unfixable CVE found)
+  - **Description**: Regenerates with fresh version impact table (adds new columns, removes old)
+  - **Comment**: Documents all changes made
+  - **Epic Link**: Re-links to current Epic
+- **For closed issues**: Skips completely (respects team's "Won't Do" decision)
+- Creates new component issues for newly discovered CVEs
+- All open issues (new + existing) linked to same Sprint3 Epic
+
+**New sprint:**
+- Creates new Epic: `CVE Remediation - Sprint4 (2026-05-10)`
+- **Re-links all open component issues** from Sprint3 Epic to Sprint4 Epic
+- Creates new issues for newly discovered components
+- Sprint3 Epic becomes historical (no linked issues if all moved)
+- Current sprint shows full active CVE backlog
+
+**When issues close:**
+- Team fixes CVEs or marks "Won't Do", closes component issue
+- Closed issues automatically drop from Epic
+- Future scans skip closed issues completely (never reopened)
+- If CVEs reappear after team marked "Won't Do", issue stays closed
+- Team must manually reopen if they change their decision
+
+## Error Handling
+
+**Missing credentials:**
+- Displays error with instructions to source `~/.claude/jira-credentials.sh`
+
+**No reports found:**
+- Suggests running `make scan-cves-json-icsp` first
+
+**JIRA API errors:**
+- Shows HTTP error code and message
+- Continues processing other components
+
+**Partial update failures:**
+- Tracks which fields updated successfully vs failed
+- Adds note to JIRA comment about failures
+- Reports partial success: "Partially updated ACM-12345 (2 failures)"
+- Verbose mode shows which fields failed
+
+**Priority fallback:**
+- If "Critical" doesn't exist, tries: Blocker → Highest → Major
+- If "Major" doesn't exist, tries: High → Medium → Normal
+- Ensures priority update succeeds even with custom JIRA configs
+
+**Invalid filename formats:**
+- Skips files that don't match expected patterns
+- Prints warning for unexpected formats
+- Continues processing valid files
+
+**Sprint label normalization:**
+- Case-insensitive: "Sprint3", "sprint3", "SPRINT3" all match
+- Normalized to title case: "Sprint3"
+- Prevents duplicate Epics from case variations
+
+**Issue lifecycle:**
+- Searches for all issues (open and closed) per component using exact component name match
+- **Name normalization**: Handles both hyphens and underscores (`multiclusterhub-operator` matches `multiclusterhub_operator`)
+- **Closed issues**: Skipped completely - never reopened (respects "Won't Do" decisions)
+- **Open issues with all CVEs fixed**: Auto-closed with comment ("All CVEs resolved across all scanned versions")
+- **Open issues - smart updates**: 
+  - **Summary**: Refreshed with current CVE counts
+  - **Priority**: Escalated/demoted based on current severity (Major ↔ Critical)
+  - **Affects Version/s**: Adds new vulnerable versions, removes fixed versions
+  - **Labels**: Updated when fixability changes (all-fixable → partially-fixable → no-fix-available)
+  - **Description**: Regenerated with current version impact table
+  - **Comment**: Added documenting all changes (only if actual changes made, no comment spam)
+  - **Epic Link**: Re-linked to current sprint Epic
+- **New discoveries**: Creates new issue, links to Epic
+- **Exact matching**: `[Install] cluster-api` won't match `[CAPA] cluster-api-provider-aws`
+- No duplicate component issues (one issue per component at a time)
+
+## Notes
+
+- **Dry-run mode**: Skips all JIRA writes including Epic creation/update. Safe for testing.
+- **Default behavior**: Scans all available branches (not limited to specific versions)
+- **Auto-close**: Issues automatically closed when all CVEs fixed across all scanned versions
+- **Component name matching**: Normalizes hyphens/underscores (`cluster-api` = `cluster_api`)
+- **Sprint labels**: Case-insensitive, normalized to title case (prevents duplicates)
+- **Partial failure handling**: Continues on individual field update errors, reports what succeeded/failed
+- **Priority fallback**: Tries alternative priority names if preferred doesn't exist in JIRA project
+- **Robust parsing**: Validates filename formats, skips malformed files with warnings
+- **Sprint-based Epic with automatic re-linking**: 
+  - Epic named: `CVE Remediation - {sprint} ({date})`
+  - Example: "CVE Remediation - Sprint3 (2026-05-06)"
+  - **New sprint behavior**: Re-links all open component issues to new Epic
+  - Open issues move from old Epic → new Epic automatically
+  - Current sprint always shows full active CVE backlog
+  - Fixed/closed issues naturally drop off (not re-linked)
+  - No duplicate component issues across sprints
+  - Epic provides high-level tracking across all components
+  - Use `--no-epic` for flat structure without parent
+  - Prompts for sprint label if not provided via `--sprint`
+- **Deduplication**: Searches JIRA before creation to avoid duplicates
+- **Component scope**: One issue per component (not per CVE)
+- **Version impact**: Table shows which releases affected by each CVE
+- **Priority mapping**: CRITICAL CVEs → Critical priority, HIGH only → Major
+- **Team assignment**: Uses component registry to assign correct JIRA component
+  - `multiclusterhub_operator` → Installer component
+  - `cert_policy_controller` → GRC component
+  - `cluster_proxy` → Server Foundation component
+  - Falls back to "Installer" if component not in registry
+- **Labels**: All issues get `cve`, `security`, `automated`, `cve-scanner` labels
+  - Fixability: `all-fixable`, `partially-fixable`, `no-fix-available`
+  - Upstream status: `no-upstream-fix` (when all CVEs unfixable - blocked upstream)
+  - Package scope: `single-package`, `multi-package`
+
+## Related Commands
+
+- **Run CVE scan**: `make scan-cves-json-icsp` (in main repo)
+- **Check reports**: `ls reports/*/json/` (see available versions)
+- **Search JIRA**: Use installer-jira-search skill to find existing CVE issues

--- a/.claude/skills/cve-to-jira/scripts/cli.py
+++ b/.claude/skills/cve-to-jira/scripts/cli.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""CVE-to-JIRA CLI entry point"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from .cve_analyzer import CVEAnalyzer
+from .jira_client import JiraClient
+from .issue_creator import IssueCreator
+from .component_mapping import ComponentMapping
+
+console = Console()
+
+
+def parse_args():
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(
+        description='Create JIRA issues from CVE scan reports',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --dry-run                           # Preview issues for default branches
+  %(prog)s --branches 2.17,2.15                # Create issues for specific branches
+  %(prog)s --component multiclusterhub_operator --dry-run  # Preview single component
+  %(prog)s --all-branches                      # Process all available branches
+        """
+    )
+
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview issues without creating them (recommended for first run)'
+    )
+
+    parser.add_argument(
+        '--branches',
+        type=str,
+        help='Comma-separated list of specific branches to scan (e.g., "2.17,2.15,2.13"). Default: all available'
+    )
+
+    parser.add_argument(
+        '--component',
+        type=str,
+        help='Process only this component (useful for testing)'
+    )
+
+    parser.add_argument(
+        '--reports-dir',
+        type=str,
+        default='reports',
+        help='Path to reports directory (default: reports)'
+    )
+
+    parser.add_argument(
+        '--no-epic',
+        action='store_true',
+        help='Do not create Epic (create standalone issues)'
+    )
+
+    parser.add_argument(
+        '--sprint',
+        type=str,
+        help='Sprint label for Epic name (e.g., "Sprint3"). Auto-detects or prompts if not provided.'
+    )
+
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Show verbose output including API calls'
+    )
+
+    return parser.parse_args()
+
+
+def get_versions(args, analyzer):
+    """Determine which versions to process
+
+    Args:
+        args: Parsed arguments
+        analyzer: CVEAnalyzer instance
+
+    Returns:
+        List of version strings
+    """
+    if args.branches:
+        # User-specified versions
+        versions = [v.strip() for v in args.branches.split(',')]
+        # Normalize versions - find latest z-stream if y-stream provided
+        normalized = []
+        reports_path = Path(args.reports_dir)
+
+        for v in versions:
+            if v.count('.') == 1:
+                # Y-stream provided (e.g., "2.15"), find latest z-stream
+                # Look for directories matching pattern: 2.15.X
+                matching = []
+                for item in reports_path.iterdir():
+                    if item.is_dir() and item.name.startswith(f"{v}."):
+                        # Extract z-stream number
+                        parts = item.name.split('.')
+                        if len(parts) == 3:  # Must be x.y.z format
+                            try:
+                                z = int(parts[2])
+                                matching.append((z, item.name))
+                            except ValueError:
+                                pass  # Skip non-numeric z-streams
+
+                if matching:
+                    # Pick latest z-stream (highest z number)
+                    latest = sorted(matching, reverse=True)[0][1]
+                    normalized.append(latest)
+                    console.print(f"[blue]Using latest z-stream for {v}: {latest}[/blue]")
+                else:
+                    # No z-streams found, try exact match
+                    normalized.append(v)
+            else:
+                # Full version provided, use as-is
+                normalized.append(v)
+        return normalized
+    else:
+        # Default: scan all available versions
+        versions = analyzer.get_available_versions()
+        console.print(f"[blue]Found {len(versions)} versions: {', '.join(versions)}[/blue]")
+        return versions
+
+
+def main():
+    """Main CLI entry point"""
+    args = parse_args()
+
+    # Print header
+    mode_str = "DRY RUN" if args.dry_run else "LIVE MODE"
+    console.print(Panel(
+        f"[bold]CVE-to-JIRA Issue Creator[/bold]\n"
+        f"Mode: [yellow]{mode_str}[/yellow]",
+        border_style="cyan"
+    ))
+
+    # Initialize analyzer
+    reports_dir = Path(args.reports_dir)
+    if not reports_dir.exists():
+        console.print(f"[red]Error: Reports directory not found: {reports_dir}[/red]")
+        console.print("Run CVE scan first: make scan-cves-json-icsp")
+        return 1
+
+    analyzer = CVEAnalyzer(reports_dir)
+
+    # Determine versions to process
+    versions = get_versions(args, analyzer)
+    if not versions:
+        console.print("[red]Error: No versions found to process[/red]")
+        return 1
+
+    console.print(f"[blue]Scanning versions:[/blue] {', '.join(versions)}")
+    if args.component:
+        console.print(f"[blue]Component filter:[/blue] {args.component}")
+    console.print()
+
+    # Initialize JIRA client (even for dry-run, to test connection)
+    try:
+        jira = JiraClient()
+        if not jira.test_connection():
+            console.print("[red]JIRA connection test failed[/red]")
+            console.print("Check credentials in ~/.claude/jira-credentials.sh")
+            return 1
+        if args.verbose:
+            console.print(f"[green]✓ JIRA connection OK ({jira.email})[/green]\n")
+    except Exception as e:
+        console.print(f"[red]JIRA client error: {e}[/red]")
+        console.print("\nMake sure to source credentials first:")
+        console.print("  source ~/.claude/jira-credentials.sh")
+        return 1
+
+    # Scan CVE reports
+    console.print("[cyan]Analyzing CVE reports...[/cyan]")
+    components_data = analyzer.scan_versions(versions, component_filter=args.component)
+
+    if not components_data:
+        console.print("[yellow]No CVEs found in reports[/yellow]")
+        return 0
+
+    console.print(f"[green]✓ Found {len(components_data)} components with CVEs[/green]\n")
+
+    # Initialize component mapping
+    component_mapping = ComponentMapping()
+    if component_mapping.is_loaded and args.verbose:
+        console.print("[green]✓ Component registry loaded[/green]")
+    elif args.verbose:
+        console.print("[yellow]⚠ Component registry not found, using default component (Installer)[/yellow]")
+
+    # Initialize issue creator
+    issue_creator = IssueCreator(versions, component_mapping=component_mapping)
+
+    # Create Epic if requested (skip in dry-run)
+    epic_key = None
+    if not args.no_epic:
+        if args.dry_run:
+            console.print("[cyan]Would create/update Epic for sprint (dry-run mode)[/cyan]\n")
+            epic_key = "DRY-RUN-EPIC"
+        else:
+            try:
+                from datetime import datetime
+                versions_str = ', '.join(versions)
+                date_str = datetime.now().strftime('%Y-%m-%d')
+
+                total_critical = sum(c.critical_count for c in components_data.values())
+                total_high = sum(c.high_count for c in components_data.values())
+
+                # Get sprint label (normalize to title case)
+                sprint_label = args.sprint
+                if not sprint_label:
+                    # Prompt for sprint
+                    from rich.prompt import Prompt
+                    sprint_label = Prompt.ask(
+                        "[yellow]Enter sprint label for Epic[/yellow]",
+                        default="Sprint3"
+                    )
+
+                # Normalize to title case for consistency (Sprint3, not sprint3 or SPRINT3)
+                sprint_label = sprint_label.strip().title()
+
+                # Check for existing Epic
+                existing_epic = jira.find_epic_by_sprint(sprint_label)
+
+                epic_summary = f"CVE Remediation - {sprint_label} ({date_str})"
+                epic_description = f"""h3. CVE Remediation Epic - {sprint_label}
+
+*Sprint:* {sprint_label}
+*Last Scanned:* {date_str}
+*Versions Scanned:* {versions_str}
+*Total Components:* {len(components_data)}
+*Total CVEs:* {total_critical} CRITICAL, {total_high} HIGH
+
+This Epic tracks CVE remediation across {len(components_data)} components for {sprint_label}.
+
+Each linked issue contains:
+- Version impact table showing which releases affected
+- CVE details with NVD links
+- Fixability analysis
+- Remediation recommendations
+
+h3. Progress Tracking
+
+Track component-level remediation in linked issues below. Close Epic when all critical/high CVEs addressed.
+
+---
+_Generated by cve-to-jira skill | Last updated: {date_str}_"""
+
+                if existing_epic:
+                    # Update existing Epic with new date
+                    console.print(f"[cyan]Updating existing Epic {existing_epic} with new scan date...[/cyan]")
+                    jira.update_epic_summary(existing_epic, epic_summary)
+                    jira.update_epic_description(existing_epic, epic_description)
+                    epic_key = existing_epic
+                    console.print(f"[green]✓ Updated Epic: {epic_key} ({sprint_label}, {date_str})[/green]\n")
+                else:
+                    # Create new Epic
+                    console.print(f"[cyan]Creating CVE remediation Epic for {sprint_label}...[/cyan]")
+                    # Map versions to JIRA format (e.g., "2.15.2" → "ACM 2.15.2")
+                    jira_versions = [IssueCreator.map_version_to_jira(v) for v in versions]
+                    epic_key = jira.create_epic(
+                        summary=epic_summary,
+                        description=epic_description,
+                        components=["Installer"],  # Epic gets default component
+                        affects_versions=jira_versions
+                    )
+                    console.print(f"[green]✓ Created Epic: {epic_key} ({sprint_label}, {date_str})[/green]\n")
+            except Exception as e:
+                console.print(f"[yellow]⚠ Failed to create Epic: {e}[/yellow]")
+                console.print("[yellow]  Continuing with standalone issues...[/yellow]\n")
+                epic_key = None
+
+    # Process each component
+    results = {
+        'created': [],
+        'relinked': [],
+        'updated': [],
+        'closed': [],
+        'skipped': [],
+        'errors': [],
+        'previews': [],
+        'epic_key': epic_key
+    }
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console
+    ) as progress:
+        task = progress.add_task(
+            f"[cyan]Processing {len(components_data)} components...",
+            total=len(components_data)
+        )
+
+        for component_name, component_data in components_data.items():
+            progress.update(task, description=f"[cyan]Checking {component_name}...")
+
+            # Check for existing issue
+            try:
+                existing_issue = jira.find_cve_issue(component_name, component_data.publish_name)
+
+                if existing_issue:
+                    issue_key = existing_issue['key']
+                    issue_status = existing_issue['status']
+                    # Unmap versions from JIRA format ("ACM 2.15.2" → "2.15.2")
+                    jira_versions = existing_issue.get('affects_versions', [])
+                    current_versions = set(IssueCreator.unmap_version_from_jira(v) for v in jira_versions)
+                    current_priority = existing_issue.get('priority', 'Major')
+                    current_labels = set(existing_issue.get('labels', []))
+
+                    # Check if issue is closed - skip completely
+                    if issue_status in ('Closed', 'Done', 'Resolved'):
+                        results['skipped'].append({
+                            'component': component_name,
+                            'issue': issue_key,
+                            'status': issue_status
+                        })
+                        if args.verbose:
+                            console.print(f"  [yellow]⊗ {component_name}: Issue {issue_key} closed ({issue_status}) - skipping[/yellow]")
+                        progress.advance(task)
+                        continue
+
+                    # Issue is open - check what needs updating
+                    new_versions = set(sorted(list(component_data.affected_versions), reverse=True))
+
+                    # Check if all CVEs fixed (no versions affected)
+                    if not new_versions:
+                        if not args.dry_run:
+                            try:
+                                # Close issue - all CVEs resolved
+                                close_comment = (
+                                    "CVE scan update:\n"
+                                    "- All CVEs resolved across all scanned versions\n"
+                                    "- Automatically closing issue\n"
+                                    "- Reopen manually if CVEs reappear"
+                                )
+                                jira.close_issue(issue_key, close_comment)
+                                console.print(f"  [green]✓ {component_name}: Closed {issue_key} (all CVEs fixed)[/green]")
+                                results['closed'].append({
+                                    'component': component_name,
+                                    'issue': issue_key,
+                                    'cves': 0
+                                })
+                            except Exception as e:
+                                if args.verbose:
+                                    console.print(f"  [yellow]⚠ {component_name}: Failed to close - {e}[/yellow]")
+                        else:
+                            # Dry run
+                            console.print(f"  [green]✓ {component_name}: Would close {issue_key} (all CVEs fixed)[/green]")
+                            results['closed'].append({
+                                'component': component_name,
+                                'issue': issue_key,
+                                'cves': 0
+                            })
+                        progress.advance(task)
+                        continue
+
+                    # Generate fresh issue data
+                    issue_data = issue_creator.create_issue_data(component_data)
+                    new_priority = issue_data['priority']
+                    new_labels = set(issue_data['labels'])
+                    new_summary = issue_data['summary']
+
+                    # Detect changes
+                    versions_changed = new_versions != current_versions
+                    priority_changed = new_priority != current_priority
+                    # Only check fixability/package labels (preserve other labels)
+                    fixability_labels = {'all-fixable', 'partially-fixable', 'no-fix-available', 'no-upstream-fix', 'single-package', 'multi-package'}
+                    current_fixability = current_labels & fixability_labels
+                    new_fixability = new_labels & fixability_labels
+                    labels_changed = current_fixability != new_fixability
+
+                    anything_changed = versions_changed or priority_changed or labels_changed
+
+                    if not args.dry_run and anything_changed:
+                        # Track update successes/failures
+                        update_results = {
+                            'versions': False,
+                            'priority': False,
+                            'labels': False,
+                            'summary': False,
+                            'description': False,
+                            'comment': False
+                        }
+                        update_errors = []
+                        comment_parts = ["CVE scan update:"]
+
+                        # Update versions
+                        if versions_changed:
+                            try:
+                                # Map versions to JIRA format (e.g., "2.15.2" → "ACM 2.15.2")
+                                jira_new_versions = [IssueCreator.map_version_to_jira(v) for v in new_versions]
+                                jira.update_affects_versions(issue_key, jira_new_versions)
+                                update_results['versions'] = True
+                                added = new_versions - current_versions
+                                removed = current_versions - new_versions
+                                if added:
+                                    comment_parts.append(f"- Added versions: {', '.join(sorted(added, reverse=True))}")
+                                if removed:
+                                    comment_parts.append(f"- Removed versions: {', '.join(sorted(removed, reverse=True))}")
+                            except Exception as e:
+                                update_errors.append(f"versions: {e}")
+
+                        # Update priority
+                        if priority_changed:
+                            try:
+                                jira.update_priority(issue_key, new_priority)
+                                update_results['priority'] = True
+                                comment_parts.append(f"- Priority changed: {current_priority} → {new_priority}")
+                            except Exception as e:
+                                update_errors.append(f"priority: {e}")
+
+                        # Update labels (merge with non-fixability labels)
+                        if labels_changed:
+                            try:
+                                merged_labels = list((current_labels - fixability_labels) | new_fixability)
+                                jira.update_labels(issue_key, merged_labels)
+                                update_results['labels'] = True
+                                comment_parts.append(f"- Fixability changed: {', '.join(sorted(current_fixability))} → {', '.join(sorted(new_fixability))}")
+                            except Exception as e:
+                                update_errors.append(f"labels: {e}")
+
+                        # Update summary (always, to reflect new CVE counts)
+                        try:
+                            jira.update_summary(issue_key, new_summary)
+                            update_results['summary'] = True
+                        except Exception as e:
+                            update_errors.append(f"summary: {e}")
+
+                        # Regenerate description with updated tables
+                        try:
+                            jira.update_description(issue_key, issue_data['description'])
+                            update_results['description'] = True
+                            comment_parts.append(f"- Total CVEs: {component_data.critical_count} CRITICAL, {component_data.high_count} HIGH")
+                            comment_parts.append(f"- Summary and description refreshed")
+                        except Exception as e:
+                            update_errors.append(f"description: {e}")
+
+                        # Add comment if we have meaningful changes and at least some updates succeeded
+                        if len(comment_parts) > 1 and any(update_results.values()):
+                            try:
+                                # Note any partial failures in comment
+                                if update_errors:
+                                    comment_parts.append(f"\n⚠️ Some updates failed: {', '.join(update_errors)}")
+                                jira.add_comment(issue_key, "\n".join(comment_parts))
+                                update_results['comment'] = True
+                            except Exception as e:
+                                update_errors.append(f"comment: {e}")
+
+                        # Report results
+                        if update_errors:
+                            console.print(f"  [yellow]⚠ {component_name}: Partially updated {issue_key} ({len(update_errors)} failures)[/yellow]")
+                            if args.verbose:
+                                for error in update_errors:
+                                    console.print(f"    - {error}")
+                        else:
+                            console.print(f"  [green]↻ {component_name}: Updated {issue_key}[/green]")
+
+                        # Re-link to Epic if we have one
+                        if epic_key:
+                            try:
+                                jira.link_to_epic(issue_key, epic_key)
+                                if not anything_changed:
+                                    console.print(f"  [blue]↪ {component_name}: Re-linked {issue_key}[/blue]")
+                            except Exception as e:
+                                if args.verbose:
+                                    console.print(f"  [yellow]⚠ {component_name}: Failed to re-link - {e}[/yellow]")
+
+                        # Track results
+                        if anything_changed:
+                            results['updated'].append({
+                                'component': component_name,
+                                'issue': issue_key,
+                                'cves': component_data.total_count
+                            })
+                        else:
+                            results['relinked'].append({
+                                'component': component_name,
+                                'issue': issue_key,
+                                'cves': component_data.total_count
+                            })
+                    else:
+                        # Dry run
+                        if anything_changed:
+                            results['updated'].append({
+                                'component': component_name,
+                                'issue': issue_key,
+                                'cves': component_data.total_count
+                            })
+                            if args.verbose:
+                                changes = []
+                                if versions_changed:
+                                    changes.append("versions")
+                                if priority_changed:
+                                    changes.append("priority")
+                                if labels_changed:
+                                    changes.append("labels")
+                                console.print(f"  [cyan]↪ {component_name}: Would update {issue_key} ({', '.join(changes)})[/cyan]")
+                        else:
+                            results['relinked'].append({
+                                'component': component_name,
+                                'issue': issue_key,
+                                'cves': component_data.total_count
+                            })
+                            if args.verbose:
+                                console.print(f"  [cyan]↪ {component_name}: Would re-link {issue_key}[/cyan]")
+
+                    progress.advance(task)
+                    continue
+
+            except Exception as e:
+                results['errors'].append({
+                    'component': component_name,
+                    'error': str(e)
+                })
+                console.print(f"  [red]✗ {component_name}: Search failed - {e}[/red]")
+                progress.advance(task)
+                continue
+
+            # Create issue data
+            issue_data = issue_creator.create_issue_data(component_data)
+
+            # Get assignee from component mapping (if available)
+            assignee = component_mapping.get_assignee(component_name)
+
+            if args.dry_run:
+                # Dry run: just record preview
+                results['previews'].append({
+                    'component': component_name,
+                    'data': component_data,
+                    'issue': issue_data
+                })
+                if args.verbose:
+                    assignee_str = f" → {assignee}" if assignee else ""
+                    console.print(f"  [cyan]◎ {component_name}: Would create issue{assignee_str}[/cyan]")
+            else:
+                # Live mode: create issue
+                try:
+                    issue_key = jira.create_issue(
+                        summary=issue_data['summary'],
+                        description=issue_data['description'],
+                        priority=issue_data['priority'],
+                        labels=issue_data['labels'],
+                        affects_versions=issue_data['affects_versions'],
+                        components=issue_data['components'],
+                        assignee=assignee
+                    )
+
+                    # Link to Epic if created
+                    if epic_key:
+                        try:
+                            jira.link_to_epic(issue_key, epic_key)
+                        except Exception as e:
+                            if args.verbose:
+                                console.print(f"    [yellow]⚠ Failed to link to Epic: {e}[/yellow]")
+
+                    results['created'].append({
+                        'component': component_name,
+                        'issue': issue_key,
+                        'cves': component_data.total_count
+                    })
+                    console.print(f"  [green]✓ {component_name}: Created {issue_key}[/green]")
+
+                except Exception as e:
+                    results['errors'].append({
+                        'component': component_name,
+                        'error': str(e)
+                    })
+                    console.print(f"  [red]✗ {component_name}: Failed - {e}[/red]")
+
+            progress.advance(task)
+
+    # Print summary
+    console.print()
+    console.print("[bold cyan]Summary[/bold cyan]")
+    console.print("=" * 60)
+
+    if args.dry_run:
+        console.print(f"[cyan]Would create:[/cyan] {len(results['previews'])} issues")
+        console.print(f"[cyan]Would update:[/cyan] {len(results['updated'])} existing issues")
+        console.print(f"[cyan]Would close:[/cyan] {len(results['closed'])} resolved issues (all CVEs fixed)")
+        console.print(f"[cyan]Would re-link:[/cyan] {len(results['relinked'])} existing issues")
+        console.print(f"[yellow]Would skip:[/yellow] {len(results['skipped'])} already-closed issues")
+    else:
+        console.print(f"[green]Created:[/green] {len(results['created'])} new issues")
+        console.print(f"[green]Updated:[/green] {len(results['updated'])} existing issues")
+        console.print(f"[green]Closed:[/green] {len(results['closed'])} resolved issues (all CVEs fixed)")
+        console.print(f"[blue]Re-linked:[/blue] {len(results['relinked'])} existing issues")
+        console.print(f"[yellow]Skipped:[/yellow] {len(results['skipped'])} already-closed issues")
+
+    console.print(f"[red]Errors:[/red] {len(results['errors'])} components")
+    console.print(f"[blue]Total processed:[/blue] {len(components_data)} components")
+
+    if epic_key:
+        total_linked = len(results['created']) + len(results['updated']) + len(results['relinked'])
+        console.print(f"[magenta]Epic:[/magenta] {epic_key} ({total_linked} issues linked)")
+
+    # Show details in table
+    if results['created']:
+        console.print("\n[bold green]Created Issues:[/bold green]")
+        table = Table(show_header=True)
+        table.add_column("Component", style="cyan")
+        table.add_column("Issue", style="green")
+        table.add_column("CVEs", justify="right", style="yellow")
+
+        for item in results['created']:
+            table.add_row(item['component'], item['issue'], str(item['cves']))
+
+        console.print(table)
+
+    if results['previews'] and (args.verbose or len(results['previews']) <= 10):
+        console.print("\n[bold cyan]Preview (would create):[/bold cyan]")
+        for item in results['previews'][:10]:  # Show first 10
+            console.print(f"\n[bold]{item['component']}[/bold]")
+            console.print(issue_creator.format_preview(item['data']))
+            console.print("─" * 60)
+
+        if len(results['previews']) > 10:
+            console.print(f"\n... and {len(results['previews']) - 10} more components")
+
+    if results['relinked'] and args.verbose:
+        console.print("\n[bold blue]Re-linked Issues:[/bold blue]")
+        table = Table(show_header=True)
+        table.add_column("Component", style="cyan")
+        table.add_column("Issue", style="blue")
+        table.add_column("CVEs", justify="right", style="yellow")
+
+        for item in results['relinked'][:20]:
+            table.add_row(item['component'], item['issue'], str(item['cves']))
+
+        console.print(table)
+
+        if len(results['relinked']) > 20:
+            console.print(f"... and {len(results['relinked']) - 20} more")
+
+    if results['errors']:
+        console.print("\n[bold red]Errors:[/bold red]")
+        for item in results['errors']:
+            console.print(f"  {item['component']}: {item['error']}")
+
+    # Final message
+    console.print()
+    if args.dry_run and (results['previews'] or results['updated'] or results['closed'] or results['relinked']):
+        console.print("[yellow]Run without --dry-run to create/update/close/re-link issues[/yellow]")
+    elif results['created'] or results['updated'] or results['closed'] or results['relinked']:
+        msg_parts = []
+        if results['created']:
+            msg_parts.append(f"created {len(results['created'])}")
+        if results['updated']:
+            msg_parts.append(f"updated {len(results['updated'])}")
+        if results['closed']:
+            msg_parts.append(f"closed {len(results['closed'])}")
+        if results['relinked']:
+            msg_parts.append(f"re-linked {len(results['relinked'])}")
+        console.print(f"[green]✓ Successfully {', '.join(msg_parts)} issues[/green]")
+
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Cancelled by user[/yellow]")
+        sys.exit(130)
+    except Exception as e:
+        console.print(f"\n[red]Fatal error: {e}[/red]")
+        if '--verbose' in sys.argv:
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)

--- a/.claude/skills/cve-to-jira/scripts/component_mapping.py
+++ b/.claude/skills/cve-to-jira/scripts/component_mapping.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Component to team mapping from acm-config registry"""
+
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+class ComponentMapping:
+    """Load and query component registry for team/squad information"""
+
+    def __init__(self, registry_path: Optional[str] = None):
+        """Initialize component mapping
+
+        Args:
+            registry_path: Path to component-registry.yaml (auto-detects if None)
+        """
+        self.registry_path = registry_path or self._find_registry()
+        self.components: Dict[str, dict] = {}
+
+        if self.registry_path and Path(self.registry_path).exists():
+            self._load_registry()
+
+    def _find_registry(self) -> Optional[str]:
+        """Auto-detect component registry location
+
+        Returns:
+            Path to component-registry.yaml or None
+        """
+        # Try common locations
+        candidates = [
+            Path.home() / "dislbenn" / "acm-config" / "product" / "component-registry.yaml",
+            Path.home() / "stolostron" / "acm-config" / "product" / "component-registry.yaml",
+            Path(os.getcwd()) / "component-registry.yaml",
+        ]
+
+        for path in candidates:
+            if path.exists():
+                return str(path)
+
+        return None
+
+    def _load_registry(self):
+        """Load component registry YAML"""
+        if yaml is None:
+            # PyYAML not available, skip loading
+            return
+
+        try:
+            with open(self.registry_path, 'r') as f:
+                data = yaml.safe_load(f)
+
+            # Build mapping: component name -> component data
+            for component in data.get('components', []):
+                name = component.get('name', '')
+                if name:
+                    # Store by both hyphen and underscore versions
+                    self.components[name] = component
+                    # Also store underscore version (CVE scanner format)
+                    underscore_name = name.replace('-', '_')
+                    self.components[underscore_name] = component
+
+        except Exception as e:
+            # Silent fail - registry is optional
+            pass
+
+    def get_jira_component(self, component_name: str) -> str:
+        """Get JIRA component for a component
+
+        Args:
+            component_name: Component name (with hyphens or underscores)
+
+        Returns:
+            JIRA component name (e.g., "GRC", "Installer", "Server Foundation")
+            Defaults to "Installer" if not found
+        """
+        # Try direct lookup
+        if component_name in self.components:
+            return self.components[component_name].get('jira_component', 'Installer')
+
+        # Try with underscore/hyphen swap
+        alt_name = component_name.replace('_', '-') if '_' in component_name else component_name.replace('-', '_')
+        if alt_name in self.components:
+            return self.components[alt_name].get('jira_component', 'Installer')
+
+        # Default to Installer
+        return 'Installer'
+
+    def get_squad(self, component_name: str) -> Optional[str]:
+        """Get squad/team for a component
+
+        Args:
+            component_name: Component name (with hyphens or underscores)
+
+        Returns:
+            Squad name (e.g., "GRC", "Install", "Server Foundation") or None
+        """
+        # Try direct lookup
+        if component_name in self.components:
+            return self.components[component_name].get('squad')
+
+        # Try with underscore/hyphen swap
+        alt_name = component_name.replace('_', '-') if '_' in component_name else component_name.replace('-', '_')
+        if alt_name in self.components:
+            return self.components[alt_name].get('squad')
+
+        return None
+
+    def get_repository(self, component_name: str) -> Optional[str]:
+        """Get GitHub repository URL for a component
+
+        Args:
+            component_name: Component name (with hyphens or underscores)
+
+        Returns:
+            Repository URL or None
+        """
+        # Try direct lookup
+        if component_name in self.components:
+            return self.components[component_name].get('repository')
+
+        # Try with underscore/hyphen swap
+        alt_name = component_name.replace('_', '-') if '_' in component_name else component_name.replace('-', '_')
+        if alt_name in self.components:
+            return self.components[alt_name].get('repository')
+
+        return None
+
+    def get_assignee(self, component_name: str) -> Optional[str]:
+        """Get JIRA assignee account ID for a component
+
+        Args:
+            component_name: Component name (with hyphens or underscores)
+
+        Returns:
+            JIRA account ID (e.g., "627972bc23d61e006fc402ee") or None
+
+        Note:
+            Currently returns None - requires squad → account ID mapping
+            in component registry. Add 'assignee' field to registry entries
+            to enable auto-assignment.
+        """
+        # TODO: Add assignee mapping to component registry
+        # Example registry entry:
+        #   - name: "multiclusterhub-operator"
+        #     squad: "Install"
+        #     assignee: "627972bc23d61e006fc402ee"  # JIRA account ID
+
+        # Try direct lookup
+        if component_name in self.components:
+            return self.components[component_name].get('assignee')
+
+        # Try with underscore/hyphen swap
+        alt_name = component_name.replace('_', '-') if '_' in component_name else component_name.replace('-', '_')
+        if alt_name in self.components:
+            return self.components[alt_name].get('assignee')
+
+        return None
+
+    @property
+    def is_loaded(self) -> bool:
+        """Check if registry was successfully loaded
+
+        Returns:
+            True if components loaded, False otherwise
+        """
+        return len(self.components) > 0

--- a/.claude/skills/cve-to-jira/scripts/cve_analyzer.py
+++ b/.claude/skills/cve-to-jira/scripts/cve_analyzer.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""CVE analysis from Grype JSON reports"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CVEInfo:
+    """Individual CVE information"""
+    cve_id: str
+    severity: str
+    package: str
+    installed_version: str
+    fixed_version: Optional[str]
+    description: str = ""
+    epss_score: Optional[str] = None
+    epss_percentile: Optional[str] = None
+    cwe: Optional[str] = None
+    cvss_score: Optional[float] = None
+    cvss_vector: Optional[str] = None
+    redhat_url: Optional[str] = None
+    nvd_url: Optional[str] = None
+    reference_urls: List[str] = field(default_factory=list)
+
+    @property
+    def has_fix(self) -> bool:
+        return bool(self.fixed_version and self.fixed_version.strip())
+
+    @property
+    def title(self) -> str:
+        """Generate concise CVE title from description"""
+        # Extract first sentence and clean it
+        first_sentence = self.description.split('.')[0] if self.description else ""
+        # Remove "A flaw was found in" prefix
+        if first_sentence.lower().startswith("a flaw was found in "):
+            first_sentence = first_sentence[20:]
+        return first_sentence if first_sentence else self.cve_id
+
+
+@dataclass
+class ComponentCVEs:
+    """CVE data for a single component across versions"""
+    component_name: str
+    publish_name: Optional[str] = None  # Display name from extras (e.g., "acm-cli-rhel9")
+    image_ref: Optional[str] = None
+    cves: List[CVEInfo] = field(default_factory=list)
+    affected_versions: Set[str] = field(default_factory=set)
+    version_cve_map: Dict[str, List[str]] = field(default_factory=dict)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for cve in self.cves if cve.severity.upper() == 'CRITICAL')
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for cve in self.cves if cve.severity.upper() == 'HIGH')
+
+    @property
+    def total_count(self) -> int:
+        return len(self.cves)
+
+    @property
+    def fixable_count(self) -> int:
+        return sum(1 for cve in self.cves if cve.has_fix)
+
+    @property
+    def unique_packages(self) -> Set[str]:
+        """Get set of unique affected packages"""
+        return {cve.package for cve in self.cves}
+
+    @property
+    def package_count(self) -> int:
+        """Count of unique affected packages"""
+        return len(self.unique_packages)
+
+    @property
+    def priority(self) -> str:
+        """Determine JIRA priority based on CVE severity"""
+        if self.critical_count > 0:
+            return "Critical"
+        elif self.high_count > 0:
+            return "Major"
+        else:
+            return "Minor"
+
+
+class CVEAnalyzer:
+    """Analyze CVE reports and aggregate by component"""
+
+    def __init__(self, reports_dir: Path):
+        self.reports_dir = Path(reports_dir)
+
+    def parse_grype_json(self, json_file: Path) -> List[CVEInfo]:
+        """Parse Grype JSON report and extract CVE info
+
+        Args:
+            json_file: Path to Grype JSON report
+
+        Returns:
+            List of CVEInfo objects
+        """
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            print(f"Warning: Failed to parse {json_file}: {e}")
+            return []
+
+        # Check for scan errors
+        if 'error' in data:
+            error_msg = data.get('error', 'Unknown error')
+            print(f"Warning: Scan failed for {json_file.name}: {error_msg}")
+            return []
+
+        cves = []
+        seen_cves = set()  # Deduplicate CVEs within same file
+
+        for match in data.get('matches', []):
+            vuln = match.get('vulnerability', {})
+            artifact = match.get('artifact', {})
+
+            cve_id = vuln.get('id', '')
+            severity = vuln.get('severity', '').upper()
+
+            # Filter for HIGH/CRITICAL only
+            if severity not in ('HIGH', 'CRITICAL'):
+                continue
+
+            # Skip duplicates
+            if cve_id in seen_cves:
+                continue
+            seen_cves.add(cve_id)
+
+            # Extract package info
+            package_name = artifact.get('name', '')
+            installed_version = artifact.get('version', '')
+
+            # Extract fix info
+            fix_info = vuln.get('fix', {})
+            fixed_versions = fix_info.get('versions', [])
+            fixed_version = fixed_versions[0] if fixed_versions else None
+
+            # Extract description (truncate long descriptions)
+            description = vuln.get('description', cve_id)
+            if len(description) > 200:
+                description = description[:197] + "..."
+
+            # Extract EPSS data if available
+            # Grype provides this in vulnerability.epss field as a list
+            epss_raw = vuln.get('epss', [])
+            epss_score = None
+            epss_percentile = None
+            if epss_raw and isinstance(epss_raw, list) and len(epss_raw) > 0:
+                epss_data = epss_raw[0]
+                score = epss_data.get('epss')
+                percentile = epss_data.get('percentile')
+                if score is not None:
+                    epss_score = f"{float(score) * 100:.1f}%"
+                if percentile is not None:
+                    epss_percentile = f"{float(percentile) * 100:.1f}th"
+
+            # Extract CWE
+            cwe = None
+            cwes = vuln.get('cwes', [])
+            if cwes and isinstance(cwes, list) and len(cwes) > 0:
+                cwe = cwes[0].get('cwe')
+
+            # Extract CVSS score and vector
+            cvss_score = None
+            cvss_vector = None
+            cvss_list = vuln.get('cvss', [])
+            if cvss_list and isinstance(cvss_list, list) and len(cvss_list) > 0:
+                cvss = cvss_list[0]
+                metrics = cvss.get('metrics', {})
+                cvss_score = metrics.get('baseScore')
+                cvss_vector = cvss.get('vector')
+
+            # Extract URLs
+            redhat_url = vuln.get('dataSource')
+            nvd_url = None
+            reference_urls = []
+
+            # Get NVD URL and references from relatedVulnerabilities
+            related = match.get('relatedVulnerabilities', [])
+            for rel in related:
+                if rel.get('namespace') == 'nvd:cpe':
+                    nvd_url = rel.get('dataSource')
+                    reference_urls = rel.get('urls', [])
+                    break
+
+            cves.append(CVEInfo(
+                cve_id=cve_id,
+                severity=severity,
+                package=package_name,
+                installed_version=installed_version,
+                fixed_version=fixed_version,
+                description=description,
+                epss_score=epss_score,
+                epss_percentile=epss_percentile,
+                cwe=cwe,
+                cvss_score=cvss_score,
+                cvss_vector=cvss_vector,
+                redhat_url=redhat_url,
+                nvd_url=nvd_url,
+                reference_urls=reference_urls
+            ))
+
+        return cves
+
+    def load_extras_metadata(self, version: str) -> Dict[str, Dict]:
+        """Load extras JSON for version to get component metadata
+
+        Args:
+            version: Version string (e.g., "2.15.2")
+
+        Returns:
+            Dict mapping image-key to metadata (image-name, git-url, etc)
+        """
+        # Look for extras file
+        extras_path = self.reports_dir.parent / "extras" / f"{version}.json"
+        if not extras_path.exists():
+            print(f"Warning: No extras file found for {version} at {extras_path}")
+            return {}
+
+        try:
+            with open(extras_path, 'r') as f:
+                extras_data = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            print(f"Warning: Failed to load extras for {version}: {e}")
+            return {}
+
+        # Build mapping from image-key to metadata
+        metadata = {}
+        for entry in extras_data:
+            image_key = entry.get('image-key', '')
+            if image_key:
+                metadata[image_key] = {
+                    'image-name': entry.get('image-name', ''),
+                    'git-url': entry.get('git-url', ''),
+                    'is_acm': self._is_acm_image(entry.get('git-url', ''))
+                }
+        return metadata
+
+    @staticmethod
+    def _is_acm_image(git_url: str) -> bool:
+        """Check if image is from ACM/OCM (not external)
+
+        Args:
+            git_url: Git repository URL
+
+        Returns:
+            True if ACM/OCM image, False if external
+        """
+        if not git_url:
+            return False
+        return 'stolostron' in git_url or 'open-cluster-management' in git_url
+
+    def scan_versions(
+        self,
+        versions: List[str],
+        component_filter: Optional[str] = None
+    ) -> Dict[str, ComponentCVEs]:
+        """Scan CVE reports for specified versions
+
+        Args:
+            versions: List of version strings (e.g., ["2.17.0", "2.15.2"])
+            component_filter: Optional component name filter
+
+        Returns:
+            Dict mapping component name to ComponentCVEs object
+        """
+        components_data: Dict[str, ComponentCVEs] = {}
+
+        # Load extras metadata for all versions
+        all_metadata = {}
+        for version in versions:
+            all_metadata[version] = self.load_extras_metadata(version)
+
+        for version in versions:
+            # Try organized structure first (reports/version/json/)
+            version_json_dir = self.reports_dir / version / "json"
+            if not version_json_dir.exists():
+                # Try flat structure
+                version_json_dir = self.reports_dir / version
+                if not version_json_dir.exists():
+                    # Try without patch version (2.17.0 → 2.17)
+                    version_short = '.'.join(version.split('.')[:2])
+                    version_json_dir = self.reports_dir / version_short / "json"
+                    if not version_json_dir.exists():
+                        print(f"Warning: No reports found for version {version}")
+                        continue
+
+            # Find all Grype JSON reports
+            json_files = list(version_json_dir.glob(f"{version.replace('.', '')}*_grype.json"))
+            if not json_files:
+                # Try with dots
+                json_files = list(version_json_dir.glob(f"{version}*_grype.json"))
+
+            for json_file in json_files:
+                # Extract component name from filename
+                # Format: {version}_{component}_grype.json
+                filename = json_file.stem
+
+                # Validate filename format
+                if not filename.endswith('_grype'):
+                    print(f"Warning: Skipping file with unexpected format: {json_file.name}")
+                    continue
+
+                # Remove version prefix and _grype suffix
+                component_name = None
+                for v in [version, version.replace('.', '')]:
+                    if filename.startswith(v):
+                        # Remove version prefix and underscore
+                        remainder = filename[len(v):].lstrip('_')
+                        # Remove _grype suffix
+                        component_name = remainder.replace('_grype', '')
+                        break
+
+                # If version prefix removal failed, try extracting component from middle
+                if not component_name or not component_name.strip():
+                    # Fallback: extract between first underscore and _grype
+                    parts = filename.split('_')
+                    if len(parts) >= 3:  # At least: version, component, grype
+                        component_name = '_'.join(parts[1:-1])  # Everything between version and grype
+                    else:
+                        print(f"Warning: Could not extract component name from: {json_file.name}")
+                        continue
+
+                # Get metadata for this component
+                metadata = all_metadata.get(version, {}).get(component_name, {})
+
+                # Skip external images (not from stolostron/open-cluster-management)
+                if metadata and not metadata.get('is_acm', False):
+                    continue
+
+                # Apply component filter
+                if component_filter and component_name != component_filter:
+                    continue
+
+                # Parse CVEs
+                cves = self.parse_grype_json(json_file)
+
+                if not cves:
+                    continue
+
+                # Initialize component data if needed
+                if component_name not in components_data:
+                    publish_name = metadata.get('image-name', '') if metadata else ''
+                    components_data[component_name] = ComponentCVEs(
+                        component_name=component_name,
+                        publish_name=publish_name if publish_name else None
+                    )
+
+                comp_data = components_data[component_name]
+                comp_data.affected_versions.add(version)
+
+                # Track which CVEs appear in which versions
+                comp_data.version_cve_map[version] = [cve.cve_id for cve in cves]
+
+                # Merge CVEs (deduplicate across versions)
+                existing_cve_ids = {cve.cve_id for cve in comp_data.cves}
+                for cve in cves:
+                    if cve.cve_id not in existing_cve_ids:
+                        comp_data.cves.append(cve)
+                        existing_cve_ids.add(cve.cve_id)
+
+        return components_data
+
+    def get_available_versions(self) -> List[str]:
+        """Get list of available versions with CVE reports
+
+        Returns:
+            List of version strings sorted descending
+        """
+        versions = []
+
+        # Look for version directories
+        for item in self.reports_dir.iterdir():
+            if item.is_dir() and item.name[0].isdigit():
+                versions.append(item.name)
+
+        # Sort descending (newest first)
+        versions.sort(reverse=True)
+        return versions

--- a/.claude/skills/cve-to-jira/scripts/issue_creator.py
+++ b/.claude/skills/cve-to-jira/scripts/issue_creator.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""JIRA issue formatter for CVE reports"""
+
+from datetime import datetime
+from typing import List, Optional
+from .cve_analyzer import ComponentCVEs
+from .component_mapping import ComponentMapping
+
+
+class IssueCreator:
+    """Format CVE data into JIRA issues"""
+
+    def __init__(self, versions: List[str], component_mapping: Optional[ComponentMapping] = None):
+        self.versions = sorted(versions, reverse=True)  # Newest first
+        self.component_mapping = component_mapping or ComponentMapping()
+
+    @staticmethod
+    def map_version_to_jira(version: str) -> str:
+        """Map version string to JIRA format
+
+        Args:
+            version: Version string (e.g., "2.7.2", "2.9.4")
+
+        Returns:
+            JIRA version format (e.g., "MCE 2.7.2")
+        """
+        return f"MCE {version}"
+
+    @staticmethod
+    def unmap_version_from_jira(jira_version: str) -> str:
+        """Unmap JIRA version string to internal format
+
+        Args:
+            jira_version: JIRA version format (e.g., "MCE 2.7.2")
+
+        Returns:
+            Version string (e.g., "2.15.2")
+        """
+        if jira_version.startswith("MCE "):
+            return jira_version[4:]  # Strip "MCE " prefix
+        return jira_version  # Return as-is if no prefix
+
+    def create_summary(self, component: ComponentCVEs) -> str:
+        """Create issue summary/title
+
+        Args:
+            component: Component CVE data
+
+        Returns:
+            Summary string
+        """
+        severity_str = ""
+        if component.critical_count > 0:
+            severity_str = f"{component.critical_count} CRITICAL"
+            if component.high_count > 0:
+                severity_str += f", {component.high_count} HIGH"
+        elif component.high_count > 0:
+            severity_str = f"{component.high_count} HIGH"
+        else:
+            severity_str = f"{component.total_count}"
+
+        # Get squad name for prefix (defaults to component's JIRA component)
+        squad = self.component_mapping.get_squad(component.component_name)
+        if not squad:
+            # Fall back to JIRA component if squad not found
+            squad = self.component_mapping.get_jira_component(component.component_name)
+
+        # Use publish name if available (e.g., "acm-cli-rhel9"), otherwise convert underscores to hyphens
+        display_name = component.publish_name if component.publish_name else component.component_name.replace('_', '-')
+
+        return f"[{squad}] {display_name} - {severity_str} CVEs"
+
+    def create_description(self, component: ComponentCVEs) -> str:
+        """Create issue description in wiki markup
+
+        Args:
+            component: Component CVE data
+
+        Returns:
+            Wiki markup formatted description
+        """
+        desc = []
+
+        # Header
+        desc.append(f"h3. CVE Summary for {component.component_name}\n")
+
+        # Summary stats
+        desc.append(f"*Total CVEs:* {component.critical_count} CRITICAL, {component.high_count} HIGH")
+        desc.append(f"*Affected Packages:* {component.package_count} unique packages")
+        desc.append(f"*Fixable:* {component.fixable_count}/{component.total_count} have fixes available")
+
+        if component.image_ref:
+            desc.append(f"*Image:* {{{{{component.image_ref}}}}}\n")
+        else:
+            desc.append("")
+
+        # Version impact table
+        desc.append("h3. Version Impact\n")
+
+        # Table header
+        header_cols = ["CVE ID", "Severity", "Package", "Installed", "Fixed In"] + self.versions
+        desc.append("|| " + " || ".join(header_cols) + " ||")
+
+        # Sort CVEs: CRITICAL first, then HIGH, then by CVE ID
+        sorted_cves = sorted(
+            component.cves,
+            key=lambda c: (
+                0 if c.severity == 'CRITICAL' else 1,
+                c.cve_id
+            )
+        )
+
+        # Table rows
+        for cve in sorted_cves:
+            row = [
+                cve.cve_id,
+                cve.severity,
+                cve.package,
+                cve.installed_version,
+                cve.fixed_version if cve.fixed_version else "N/A"
+            ]
+
+            # Add version columns (✓ if CVE present in that version)
+            for version in self.versions:
+                version_cves = component.version_cve_map.get(version, [])
+                row.append("✓" if cve.cve_id in version_cves else "✗")
+
+            desc.append("| " + " | ".join(row) + " |")
+
+        desc.append("")  # Blank line after table
+
+        # CVE details section
+        desc.append("h3. CVE Details\n")
+
+        for cve in sorted_cves:
+            # Title line with CVE ID, severity, and concise description
+            desc.append(f"*{cve.cve_id}* ({cve.severity}) - {cve.title}")
+            desc.append(f"- Package: {cve.package} {cve.installed_version}")
+            if cve.fixed_version:
+                desc.append(f"- Fixed: {cve.fixed_version}")
+            else:
+                desc.append("- Fixed: No fix available")
+
+            # Add CWE if available
+            if cve.cwe:
+                desc.append(f"- CWE: {cve.cwe}")
+
+            # Add CVSS score and vector if available
+            if cve.cvss_score and cve.cvss_vector:
+                desc.append(f"- CVSS: {cve.cvss_score} ({cve.cvss_vector})")
+
+            # Add EPSS score if available
+            if cve.epss_score and cve.epss_percentile:
+                desc.append(f"- EPSS: {cve.epss_score} ({cve.epss_percentile} percentile)")
+
+            # Add links
+            links = []
+            if cve.redhat_url:
+                links.append(f"[Red Hat CVE|{cve.redhat_url}]")
+            if cve.nvd_url:
+                links.append(f"[NVD|{cve.nvd_url}]")
+            for i, ref_url in enumerate(cve.reference_urls[:3], 1):  # Limit to 3 refs
+                # Try to extract domain for link text
+                domain = ref_url.split('/')[2] if len(ref_url.split('/')) > 2 else f"Ref {i}"
+                links.append(f"[{domain}|{ref_url}]")
+
+            if links:
+                desc.append(f"- Links: {' | '.join(links)}")
+
+            desc.append("")  # Blank line between CVEs
+
+        # Remediation section
+        desc.append("h3. Remediation\n")
+
+        if component.fixable_count == component.total_count:
+            desc.append(f"✅ All {component.total_count} CVEs have fixes available.\n")
+        elif component.fixable_count > 0:
+            desc.append(
+                f"⚠️ {component.fixable_count} of {component.total_count} CVEs have fixes available. "
+                f"{component.total_count - component.fixable_count} CVEs have no fix yet.\n"
+            )
+        else:
+            desc.append(f"❌ None of the {component.total_count} CVEs have fixes available yet.\n")
+
+        desc.append("Recommended actions:")
+        desc.append("# Review version constraints in component repository")
+        desc.append("# Update base images where fixes are available")
+        desc.append("# File upstream issues for CVEs without fixes")
+        desc.append("# Test updated images in staging environment")
+        desc.append("# Monitor for new CVE disclosures")
+
+        # Footer
+        desc.append("\n---")
+        desc.append(f"_Generated by cve-to-jira skill | Scan date: {datetime.now().strftime('%Y-%m-%d')}_")
+
+        return "\n".join(desc)
+
+    def create_issue_data(self, component: ComponentCVEs) -> dict:
+        """Create complete issue data structure
+
+        Args:
+            component: Component CVE data
+
+        Returns:
+            Dict with summary, description, priority, labels, affects_versions, components
+        """
+        # Get JIRA component from registry (defaults to "Installer")
+        jira_component = self.component_mapping.get_jira_component(component.component_name)
+
+        # Build labels with fixability info
+        labels = ["cve", "security", "automated", "cve-scanner"]
+
+        # Add fixability labels
+        if component.fixable_count == component.total_count:
+            labels.append("all-fixable")
+        elif component.fixable_count > 0:
+            labels.append("partially-fixable")
+        else:
+            labels.append("no-fix-available")
+            labels.append("no-upstream-fix")  # All CVEs unfixable - likely blocked upstream
+
+        # Add package count category
+        if component.package_count == 1:
+            labels.append("single-package")
+        else:
+            labels.append("multi-package")
+
+        # Map versions to JIRA format (e.g., "2.15.2" → "ACM 2.15.2")
+        jira_versions = [self.map_version_to_jira(v) for v in component.affected_versions]
+
+        return {
+            "summary": self.create_summary(component),
+            "description": self.create_description(component),
+            "priority": component.priority,
+            "labels": labels,
+            "affects_versions": sorted(jira_versions, reverse=True),
+            "components": [jira_component]
+        }
+
+    def format_preview(self, component: ComponentCVEs) -> str:
+        """Format component CVE data for console preview
+
+        Args:
+            component: Component CVE data
+
+        Returns:
+            Formatted preview string
+        """
+        lines = []
+
+        lines.append(f"Component: {component.component_name}")
+        lines.append(f"CVEs: {component.critical_count} CRITICAL, {component.high_count} HIGH ({component.total_count} total)")
+        lines.append(f"Fixable: {component.fixable_count}/{component.total_count}")
+        lines.append(f"Priority: {component.priority}")
+        lines.append(f"Versions: {', '.join(sorted(component.affected_versions, reverse=True))}")
+        lines.append("")
+
+        # Show top 3 CVEs
+        sorted_cves = sorted(
+            component.cves,
+            key=lambda c: (0 if c.severity == 'CRITICAL' else 1, c.cve_id)
+        )[:3]
+
+        lines.append("Top CVEs:")
+        for cve in sorted_cves:
+            fix_str = cve.fixed_version if cve.fixed_version else "No fix"
+            lines.append(f"  • {cve.cve_id} ({cve.severity}) - {cve.package} → {fix_str}")
+
+        if component.total_count > 3:
+            lines.append(f"  ... and {component.total_count - 3} more")
+
+        return "\n".join(lines)

--- a/.claude/skills/cve-to-jira/scripts/jira_client.py
+++ b/.claude/skills/cve-to-jira/scripts/jira_client.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""JIRA API client for CVE issue management"""
+
+import base64
+import json
+import os
+import urllib.request
+import urllib.error
+from typing import Optional, Dict, List
+
+
+class JiraClient:
+    """JIRA API client using basic auth with urllib"""
+
+    def __init__(self, base_url: str = "https://redhat.atlassian.net"):
+        self.base_url = base_url
+        self.email = os.getenv("JIRA_EMAIL")
+        self.token = os.getenv("JIRA_API_TOKEN")
+
+        if not self.email or not self.token:
+            raise ValueError(
+                "JIRA credentials not found. Source ~/.claude/jira-credentials.sh first:\n"
+                "  source ~/.claude/jira-credentials.sh"
+            )
+
+    def _request(self, endpoint: str, method: str = "GET", data: Optional[Dict] = None) -> Optional[Dict]:
+        """Make authenticated request to JIRA API"""
+        url = f"{self.base_url}{endpoint}"
+        auth_string = base64.b64encode(f"{self.email}:{self.token}".encode()).decode()
+        headers = {
+            "Authorization": f"Basic {auth_string}",
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
+        req_data = json.dumps(data).encode('utf-8') if data else None
+        request = urllib.request.Request(url, data=req_data, headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                response_body = response.read().decode('utf-8')
+                if not response_body or response_body.strip() == '':
+                    return {'success': True}
+                return json.loads(response_body)
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode('utf-8') if e.fp else ""
+            if e.code == 401:
+                raise ValueError(f"JIRA authentication failed (401). Check credentials.")
+            elif e.code == 403:
+                raise ValueError(f"JIRA access forbidden (403). Check permissions.")
+            elif e.code == 404:
+                return None  # Not found is OK for searches
+            else:
+                raise ValueError(f"JIRA API error ({e.code}): {error_body}")
+        except urllib.error.URLError as e:
+            raise ValueError(f"Network error connecting to JIRA: {e}")
+
+    def search_issues(self, jql: str, max_results: int = 50) -> List[Dict]:
+        """Search for issues using JQL
+
+        Args:
+            jql: JQL query string
+            max_results: Maximum number of results to return
+
+        Returns:
+            List of issue objects with key, summary, status, etc.
+        """
+        payload = {
+            "jql": jql,
+            "maxResults": max_results,
+            "fields": ["summary", "status", "assignee", "components", "labels", "key", "versions", "priority"]
+        }
+
+        result = self._request("/rest/api/3/search/jql", method="POST", data=payload)
+        if result and 'issues' in result:
+            return result['issues']
+        return []
+
+    def find_cve_issue(self, component_name: str, publish_name: Optional[str] = None) -> Optional[Dict]:
+        """Find existing CVE issue for component
+
+        Args:
+            component_name: Component name / image-key (e.g., "multiclusterhub_operator")
+            publish_name: Optional publish name / image-name (e.g., "multiclusterhub-operator-rhel9")
+
+        Returns:
+            Issue dict with key, status, affects_versions, priority, labels if found, None otherwise
+        """
+        # Search for CVE issues matching this component (all statuses)
+        # Try component_name, hyphenated version, and publish_name
+        search_terms = [component_name]
+
+        hyphenated = component_name.replace('_', '-')
+        if hyphenated != component_name:
+            search_terms.append(hyphenated)
+
+        if publish_name and publish_name not in search_terms:
+            search_terms.append(publish_name)
+
+        # Build JQL with all search terms
+        summary_clause = ' OR '.join(f'summary ~ "{term}"' for term in search_terms)
+        jql = (
+            f'project = ACM AND '
+            f'({summary_clause}) AND '
+            f'labels in (cve)'
+        )
+
+        issues = self.search_issues(jql, max_results=10)
+
+        # Filter for exact component match in summary
+        # Summary format: "[Squad] component_name - X CVEs"
+        # Normalize both for comparison (convert to hyphens)
+        normalized_component = component_name.replace('_', '-')
+
+        for issue in issues:
+            summary = issue['fields'].get('summary', '')
+            # Extract component name between '] ' and ' -'
+            if '] ' in summary and ' -' in summary:
+                start = summary.index('] ') + 2
+                end = summary.index(' -', start)
+                issue_component = summary[start:end].strip()
+                # Normalize for comparison (handles both old underscore and new hyphen format)
+                normalized_issue_component = issue_component.replace('_', '-')
+                if normalized_issue_component == normalized_component:
+                    return {
+                        'key': issue['key'],
+                        'status': issue['fields']['status']['name'],
+                        'affects_versions': [v['name'] for v in issue['fields'].get('versions', [])],
+                        'priority': issue['fields'].get('priority', {}).get('name', 'Major'),
+                        'labels': issue['fields'].get('labels', [])
+                    }
+
+        return None
+
+    def create_issue(
+        self,
+        summary: str,
+        description: str,
+        issue_type: str = "Vulnerability",
+        priority: str = "Critical",
+        labels: Optional[List[str]] = None,
+        affects_versions: Optional[List[str]] = None,
+        components: Optional[List[str]] = None,
+        assignee: Optional[str] = None
+    ) -> str:
+        """Create JIRA issue
+
+        Args:
+            summary: Issue summary/title
+            description: Issue description in wiki markup format
+            issue_type: Issue type (Vulnerability, Bug, Task, etc.)
+            priority: Priority (Critical, Major, Minor, etc.)
+            labels: List of labels to apply
+            affects_versions: List of version strings (e.g., ["2.17.0", "2.15.2"])
+            components: List of JIRA components (e.g., ["GRC", "Installer"])
+            assignee: JIRA account ID (e.g., "627972bc23d61e006fc402ee")
+
+        Returns:
+            Created issue key (e.g., "ACM-12345")
+        """
+        if labels is None:
+            labels = ["cve", "security", "automated", "cve-scanner"]
+
+        if components is None:
+            components = ["Installer"]
+
+        payload = {
+            "fields": {
+                "project": {"key": "ACM"},
+                "summary": summary,
+                "description": description,
+                "issuetype": {"name": issue_type},
+                "components": [{"name": c} for c in components],
+                "priority": {"name": priority},
+                "labels": labels,
+                # Activity Type custom field (required for ACM)
+                "customfield_10464": {"value": "Security & Compliance"}
+            }
+        }
+
+        # Add affects versions if provided
+        if affects_versions:
+            payload["fields"]["versions"] = [{"name": v} for v in affects_versions]
+
+        # Add assignee if provided
+        if assignee:
+            payload["fields"]["assignee"] = {"accountId": assignee}
+
+        try:
+            result = self._request("/rest/api/2/issue", method="POST", data=payload)
+
+            if result and 'key' in result:
+                return result['key']
+            else:
+                raise ValueError(f"Failed to create issue. Response: {result}")
+
+        except ValueError as e:
+            # If Vulnerability type failed (likely not available), retry with Bug
+            if issue_type == "Vulnerability" and ("issuetype" in str(e).lower() or "issue type" in str(e).lower()):
+                payload["fields"]["issuetype"] = {"name": "Bug"}
+                result = self._request("/rest/api/2/issue", method="POST", data=payload)
+
+                if result and 'key' in result:
+                    return result['key']
+                else:
+                    raise ValueError(f"Failed to create issue. Response: {result}")
+            else:
+                # Re-raise original error
+                raise
+
+    def create_epic(
+        self,
+        summary: str,
+        description: str,
+        components: Optional[List[str]] = None,
+        affects_versions: Optional[List[str]] = None
+    ) -> str:
+        """Create JIRA Epic
+
+        Args:
+            summary: Epic summary/title (also used as Epic Name)
+            description: Epic description in wiki markup
+            components: List of JIRA components
+            affects_versions: List of version strings
+
+        Returns:
+            Created Epic key (e.g., "ACM-12345")
+        """
+        if components is None:
+            components = ["Installer"]
+
+        payload = {
+            "fields": {
+                "project": {"key": "ACM"},
+                "summary": summary,
+                "description": description,
+                "issuetype": {"name": "Epic"},
+                "components": [{"name": c} for c in components],
+                "priority": {"name": "Major"},
+                "labels": ["cve", "security", "automated", "cve-scanner"],
+                # Epic Name (required for Epics)
+                "customfield_10011": summary,
+                # Activity Type custom field (required for ACM)
+                "customfield_10464": {"value": "Security & Compliance"}
+            }
+        }
+
+        # Add affects versions if provided
+        if affects_versions:
+            payload["fields"]["versions"] = [{"name": v} for v in affects_versions]
+
+        result = self._request("/rest/api/2/issue", method="POST", data=payload)
+
+        if result and 'key' in result:
+            return result['key']
+        else:
+            raise ValueError(f"Failed to create Epic. Response: {result}")
+
+    def find_epic_by_sprint(self, sprint_label: str) -> Optional[str]:
+        """Find existing CVE Epic for sprint (case-insensitive)
+
+        Args:
+            sprint_label: Sprint label (e.g., "Sprint3" or "sprint3")
+
+        Returns:
+            Epic key if found, None otherwise
+        """
+        # Normalize sprint label to title case for consistency
+        normalized_sprint = sprint_label.strip().title()
+
+        jql = (
+            f'project = ACM AND '
+            f'issuetype = Epic AND '
+            f'summary ~ "CVE Remediation - {normalized_sprint}" AND '
+            f'labels in (cve) AND '
+            f'status NOT IN (Closed, Done, Resolved)'
+        )
+
+        issues = self.search_issues(jql, max_results=1)
+        if issues:
+            return issues[0]['key']
+        return None
+
+    def update_epic_summary(self, epic_key: str, new_summary: str) -> bool:
+        """Update Epic summary/title
+
+        Args:
+            epic_key: Epic key (e.g., "ACM-12345")
+            new_summary: New summary text
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "summary": new_summary,
+                # Also update Epic Name field
+                "customfield_10011": new_summary
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{epic_key}", method="PUT", data=payload)
+        return result is not None
+
+    def update_epic_description(self, epic_key: str, new_description: str) -> bool:
+        """Update Epic description
+
+        Args:
+            epic_key: Epic key (e.g., "ACM-12345")
+            new_description: New description in wiki markup
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "description": new_description
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{epic_key}", method="PUT", data=payload)
+        return result is not None
+
+    def link_to_epic(self, issue_key: str, epic_key: str) -> bool:
+        """Link issue to Epic
+
+        Args:
+            issue_key: Issue key to link (e.g., "ACM-12346")
+            epic_key: Epic key to link to (e.g., "ACM-12345")
+
+        Returns:
+            True if successful
+        """
+        # Update issue with Epic Link field (customfield_10014)
+        payload = {
+            "fields": {
+                "customfield_10014": epic_key
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        return result is not None
+
+    def update_affects_versions(self, issue_key: str, versions: List[str]) -> bool:
+        """Update issue affects versions
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            versions: List of version strings (e.g., ["2.17.0", "2.15.2"])
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "versions": [{"name": v} for v in versions]
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        return result is not None
+
+    def add_comment(self, issue_key: str, comment: str) -> bool:
+        """Add comment to issue
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            comment: Comment text (wiki markup supported)
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "body": comment
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}/comment", method="POST", data=payload)
+        return result is not None
+
+    def update_description(self, issue_key: str, description: str) -> bool:
+        """Update issue description
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            description: New description in wiki markup
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "description": description
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        return result is not None
+
+    def update_summary(self, issue_key: str, summary: str) -> bool:
+        """Update issue summary/title
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            summary: New summary text
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "summary": summary
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        return result is not None
+
+    def update_priority(self, issue_key: str, priority: str) -> bool:
+        """Update issue priority with fallback
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            priority: Priority name (e.g., "Critical", "Major")
+
+        Returns:
+            True if successful
+        """
+        # Try primary priority first
+        payload = {
+            "fields": {
+                "priority": {"name": priority}
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        if result is not None:
+            return True
+
+        # Fallback priority mapping if primary fails
+        fallbacks = {
+            "Critical": ["Blocker", "Highest", "Major"],
+            "Major": ["High", "Medium", "Normal"],
+            "Minor": ["Low", "Lowest", "Trivial"]
+        }
+
+        # Try fallbacks
+        for fallback in fallbacks.get(priority, []):
+            payload["fields"]["priority"]["name"] = fallback
+            result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+            if result is not None:
+                return True
+
+        return False
+
+    def update_labels(self, issue_key: str, labels: List[str]) -> bool:
+        """Update issue labels (replaces all labels)
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            labels: List of label strings
+
+        Returns:
+            True if successful
+        """
+        payload = {
+            "fields": {
+                "labels": labels
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}", method="PUT", data=payload)
+        return result is not None
+
+    def close_issue(self, issue_key: str, comment: Optional[str] = None) -> bool:
+        """Close/resolve issue
+
+        Args:
+            issue_key: Issue key (e.g., "ACM-12345")
+            comment: Optional comment to add before closing
+
+        Returns:
+            True if successful
+        """
+        # Add comment if provided
+        if comment:
+            self.add_comment(issue_key, comment)
+
+        # Get available transitions
+        transitions_result = self._request(f"/rest/api/2/issue/{issue_key}/transitions")
+        if not transitions_result or 'transitions' not in transitions_result:
+            return False
+
+        # Find "Close" or "Done" or "Resolve" transition
+        close_transition = None
+        for transition in transitions_result['transitions']:
+            name = transition['name'].lower()
+            if name in ('close', 'done', 'resolve', 'closed', 'resolved'):
+                close_transition = transition['id']
+                break
+
+        if not close_transition:
+            # No close transition found
+            return False
+
+        # Transition to closed
+        payload = {
+            "transition": {
+                "id": close_transition
+            }
+        }
+
+        result = self._request(f"/rest/api/2/issue/{issue_key}/transitions", method="POST", data=payload)
+        return result is not None
+
+    def test_connection(self) -> bool:
+        """Test JIRA connection and credentials
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        try:
+            result = self._request("/rest/api/2/myself")
+            return result is not None and 'emailAddress' in result
+        except Exception:
+            return False

--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -302,6 +302,15 @@ jobs:
           retention-days: 90
         continue-on-error: true
 
+      - name: Upload extras metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extras-${{ env.RELEASE_BRANCH }}
+          path: extras/
+          retention-days: 90
+        continue-on-error: true
+
       - name: Check for critical CVEs
         run: |
           # Count critical CVEs and fail if threshold exceeded
@@ -344,7 +353,15 @@ jobs:
           path: downloaded-history/
           merge-multiple: false
 
-      - name: Merge history files
+      - name: Download all extras artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: extras-*
+          path: downloaded-extras/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Merge history and extras files
         run: |
           echo "Merging history files from artifacts..."
           mkdir -p reports/trends
@@ -358,6 +375,23 @@ jobs:
 
           ls -la reports/trends/
           echo "✓ History files merged"
+
+          # Merge extras from all releases (later releases overwrite earlier)
+          echo "Merging extras metadata from artifacts..."
+          mkdir -p extras
+
+          for extras_dir in downloaded-extras/extras-*/; do
+            if [ -d "$extras_dir" ]; then
+              cp "$extras_dir"*.json extras/ || true
+            fi
+          done
+
+          if [ -d "extras" ] && [ "$(ls -A extras)" ]; then
+            echo "✓ Extras metadata merged"
+            ls -la extras/
+          else
+            echo "⚠️  No extras metadata found (internal/external categorization unavailable)"
+          fi
 
       - name: Generate multi-release dashboard
         run: |

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -281,7 +281,8 @@ def main():
             'total_cves': summary['total_cves'],
             'total_matches': summary['total_matches'],
             'by_severity': summary['by_severity'],
-            'component_breakdown': summary['component_breakdown']
+            'component_breakdown': summary['component_breakdown'],
+            'cve_details': summary['cve_details']
         },
         'new_cves': new_cves,
         'fixed_cves': fixed_cves

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -18,6 +18,7 @@ def load_history(history_file):
     if not history_file.exists():
         return {
             "release": None,
+            "version": None,
             "scans": [],
             "metadata": {
                 "created": datetime.now(timezone.utc).isoformat() + "Z",
@@ -36,43 +37,66 @@ def load_history(history_file):
         sys.exit(1)
 
 
-def extract_scan_summary(scan_report):
-    """Extract summary statistics from Grype JSON report"""
-    matches = scan_report.get('matches', [])
+def extract_image_key_from_filename(filepath):
+    """Extract image key from grype JSON filename
 
-    # Count by severity
-    severity_counts = {
-        'CRITICAL': 0,
-        'HIGH': 0,
-        'MEDIUM': 0,
-        'LOW': 0,
-        'NEGLIGIBLE': 0,
-        'UNKNOWN': 0
-    }
+    Example: 2.17.0_klusterlet_addon_controller_grype.json -> klusterlet_addon_controller
+    """
+    filename = Path(filepath).name
+    # Remove version prefix and _grype.json suffix
+    # Pattern: {version}_{image_key}_grype.json
+    parts = filename.replace('_grype.json', '').split('_')
+    # First part is version (e.g., 2.17.0), rest is image key
+    if len(parts) > 1:
+        return '_'.join(parts[1:])
+    return 'unknown'
 
-    # Track unique CVEs and components
-    cve_set = set()
-    component_breakdown = {}
-    cve_details = []
 
-    for match in matches:
-        vuln = match.get('vulnerability', {})
-        artifact = match.get('artifact', {})
+def extract_scan_summary_from_all(reports_dir):
+    """Extract summary statistics from all Grype JSON reports, grouped by image
 
-        cve_id = vuln.get('id', 'UNKNOWN')
-        severity = vuln.get('severity', 'UNKNOWN').upper()
-        component = artifact.get('name', 'unknown')
+    Args:
+        reports_dir: Path to reports directory
 
-        # Count by severity
-        if severity in severity_counts:
-            severity_counts[severity] += 1
+    Returns:
+        dict with overall stats and per-image component_breakdown
+    """
+    reports_path = Path(reports_dir)
+    json_files = list(reports_path.rglob('*_grype.json'))
 
-        # Track unique CVEs
-        cve_set.add(cve_id)
+    if not json_files:
+        console.print(f"[yellow]Warning: No Grype JSON files found in {reports_dir}[/yellow]")
+        return {
+            'total_cves': 0,
+            'total_matches': 0,
+            'by_severity': {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0},
+            'component_breakdown': {},
+            'cve_details': []
+        }
 
-        # Track per-component breakdown
-        if component not in component_breakdown:
-            component_breakdown[component] = {
+    # Global counters
+    severity_counts = {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0}
+    global_cve_set = set()
+    total_matches = 0
+    component_breakdown = {}  # keyed by image_key
+    all_cve_details = []
+
+    for json_file in json_files:
+        image_key = extract_image_key_from_filename(json_file)
+
+        try:
+            with open(json_file, 'r') as f:
+                scan_report = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            console.print(f"[yellow]Warning: Could not read {json_file}: {e}[/yellow]")
+            continue
+
+        matches = scan_report.get('matches', [])
+        total_matches += len(matches)
+
+        # Initialize image entry
+        if image_key not in component_breakdown:
+            component_breakdown[image_key] = {
                 'CRITICAL': 0,
                 'HIGH': 0,
                 'MEDIUM': 0,
@@ -80,25 +104,42 @@ def extract_scan_summary(scan_report):
                 'total': 0
             }
 
-        if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
-            component_breakdown[component][severity] += 1
-        component_breakdown[component]['total'] += 1
+        for match in matches:
+            vuln = match.get('vulnerability', {})
+            artifact = match.get('artifact', {})
 
-        # Store CVE details for new/fixed detection
-        cve_details.append({
-            'cve_id': cve_id,
-            'severity': severity,
-            'component': component,
-            'fixed_versions': vuln.get('fix', {}).get('versions', []),
-            'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
-        })
+            cve_id = vuln.get('id', 'UNKNOWN')
+            severity = vuln.get('severity', 'UNKNOWN').upper()
+            package_name = artifact.get('name', 'unknown')
+
+            # Count by severity globally
+            if severity in severity_counts:
+                severity_counts[severity] += 1
+
+            # Track unique CVEs globally
+            global_cve_set.add(cve_id)
+
+            # Count by severity per image
+            if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+                component_breakdown[image_key][severity] += 1
+            component_breakdown[image_key]['total'] += 1
+
+            # Store CVE details with image context
+            all_cve_details.append({
+                'cve_id': cve_id,
+                'severity': severity,
+                'component': image_key,  # Now this is the image, not the package
+                'package': package_name,
+                'fixed_versions': vuln.get('fix', {}).get('versions', []),
+                'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
+            })
 
     return {
-        'total_cves': len(cve_set),
-        'total_matches': len(matches),
+        'total_cves': len(global_cve_set),
+        'total_matches': total_matches,
         'by_severity': severity_counts,
         'component_breakdown': component_breakdown,
-        'cve_details': cve_details
+        'cve_details': all_cve_details
     }
 
 
@@ -136,19 +177,26 @@ def detect_changes(current_scan, previous_scan):
 
 
 def detect_release_from_extras(extras_dir):
-    """Auto-detect release version from extras directory"""
+    """Auto-detect release version from extras directory
+
+    Returns:
+        tuple: (release_name, full_version) e.g., ('release-2.17', '2.17.0')
+    """
     extras_path = Path(extras_dir)
     if not extras_path.exists():
-        return None
+        return None, None
 
     # Look for version pattern in JSON filenames (e.g., 2.17.0.json)
     for json_file in extras_path.glob('*.json'):
         name = json_file.stem
         parts = name.split('.')
-        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
-            return f"release-{parts[0]}.{parts[1]}"
+        if len(parts) >= 3 and parts[0].isdigit() and parts[1].isdigit():
+            # Return both release-X.Y and full X.Y.Z
+            release_name = f"release-{parts[0]}.{parts[1]}"
+            full_version = name  # e.g., "2.17.0"
+            return release_name, full_version
 
-    return None
+    return None, None
 
 
 def prune_old_scans(history, retention_weeks=None, max_scans=None):
@@ -188,42 +236,23 @@ def main():
 
     # Detect release if not provided
     release = args.release
+    full_version = None
     if not release:
-        release = detect_release_from_extras(args.extras_dir)
+        release, full_version = detect_release_from_extras(args.extras_dir)
         if not release:
             console.print("[red]Could not auto-detect release. Use --release flag[/red]")
             sys.exit(1)
+    else:
+        # Manual release specified, try to get version from extras
+        _, full_version = detect_release_from_extras(args.extras_dir)
 
     console.print(f"[cyan]Storing scan results for {release}[/cyan]")
+    if full_version:
+        console.print(f"[cyan]Version: {full_version}[/cyan]")
 
-    # Find scan report
-    scan_report_path = args.scan_report
-    if not scan_report_path:
-        # Look for latest Grype JSON in reports dir (search recursively)
-        reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.rglob('*_grype.json'))
-        if not json_files:
-            console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
-            sys.exit(1)
-        scan_report_path = max(json_files, key=lambda p: p.stat().st_mtime)
-
-    scan_report_path = Path(scan_report_path)
-    if not scan_report_path.exists():
-        console.print(f"[red]Scan report not found: {scan_report_path}[/red]")
-        sys.exit(1)
-
-    console.print(f"[cyan]Loading scan report: {scan_report_path}[/cyan]")
-
-    # Load scan report
-    try:
-        with open(scan_report_path, 'r') as f:
-            scan_report = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        console.print(f"[red]Error loading scan report: {e}[/red]")
-        sys.exit(1)
-
-    # Extract summary
-    summary = extract_scan_summary(scan_report)
+    # Extract summary from all Grype JSON files
+    console.print(f"[cyan]Processing all Grype scan results in {args.reports_dir}[/cyan]")
+    summary = extract_scan_summary_from_all(args.reports_dir)
 
     # Load or create history
     trends_dir = Path(args.reports_dir) / 'trends'
@@ -232,9 +261,11 @@ def main():
     history_file = trends_dir / f"{release}-history.json"
     history = load_history(history_file)
 
-    # Set release name if new history
+    # Set release name and version if new history
     if not history.get('release'):
         history['release'] = release
+    if full_version and not history.get('version'):
+        history['version'] = full_version
 
     # Get previous scan for comparison
     previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None
@@ -245,7 +276,6 @@ def main():
     # Create scan record
     scan_record = {
         'timestamp': datetime.now(timezone.utc).isoformat() + 'Z',
-        'scan_report_path': str(scan_report_path),
         'github_run_id': args.github_run_id or os.environ.get('GITHUB_RUN_ID'),
         'summary': {
             'total_cves': summary['total_cves'],


### PR DESCRIPTION
## Summary
Fixes three issues with CVE trend dashboard:
1. Components showed as packages (stdlib, golang.org/x/crypto) instead of container images
2. All components classified as external (no git_url available in aggregate job)
3. Tab labels showed x.y instead of exact x.y.z version

## Changes

**Component Grouping (scripts/store_scan_results.py):**
- Rewrite `extract_scan_summary` to process all `*_grype.json` files
- Extract image key from filename: `2.17.0_registration_operator_grype.json` → `registration_operator`
- Group CVEs by image instead of package
- Match image key to extras `image-key` field for git_url lookup

**Version Tracking (scripts/store_scan_results.py):**
- Modified `detect_release_from_extras()` to return both release name and full version
- Added `version` field to history metadata structure
- Store detected version from `extras/x.y.z.json` filename

**Dashboard Display (scripts/generate_multi_release_dashboard.py):**
- Modified `generate_tab_button()` to read version from history metadata
- Tab labels now show exact x.y.z instead of falling back to x.y

**Workflow (.github/workflows/weekly-cve-scan.yml):**
- Upload `extras/` as artifact after each scan job
- Download and merge all `extras-*` artifacts in aggregate job
- Extras merged temporarily for dashboard generation (not committed to main)

## Fixes
- Components now show as images: `registration-operator`, `cluster-proxy-addon`
- Internal components properly classified (have git_url from extras)
- External components properly classified (no git_url)
- Tabs display exact patch version: `2.17.0` not `2.17`

## Test Plan
- [ ] Manual trigger workflow with `auto_commit=true`
- [ ] Verify components grouped by image (not package)
- [ ] Verify internal/external split appears correctly
- [ ] Verify tabs show x.y.z versions
- [ ] Verify extras/ not committed to main (only reports/trends/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)