### PR TITLE
Fix workflow to use backplane branch names

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -12,17 +12,17 @@ on:
       release_branch:
         description: 'Release branch to scan'
         required: false
-        default: 'release-5.0'
+        default: 'backplane-5.0'
         type: choice
         options:
-          - release-5.0
-          - release-2.17
-          - release-2.16
-          - release-2.15
-          - release-2.14
-          - release-2.13
-          - release-2.12
-          - release-2.11
+          - backplane-5.0
+          - backplane-2.17
+          - backplane-2.11
+          - backplane-2.10
+          - backplane-2.9
+          - backplane-2.8
+          - backplane-2.7
+          - backplane-2.6
           - all
       severity:
         description: 'CVE severity levels to scan'
@@ -48,7 +48,7 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13"]') || inputs.release_branch == 'all' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13", "release-2.12", "release-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8"]') || inputs.release_branch == 'all' && fromJSON('["backplane-5.0", "backplane-2.17", "backplane-2.11", "backplane-2.10", "backplane-2.9", "backplane-2.8", "backplane-2.7", "backplane-2.6"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:


### PR DESCRIPTION
## Summary
Workflow using `release-*` branch names but MCE uses `backplane-*`.

## Changes
- Update inputs to backplane-5.0, backplane-2.17, backplane-2.11, etc.
- Update matrix to use backplane-* for scheduled runs

## Fixes
Workflow can now checkout correct MCE release branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)