### PR TITLE
Remove postgresql-13 from external images

### DIFF
--- a/config/mce-manifest-gen-config.json
+++ b/config/mce-manifest-gen-config.json
@@ -76,9 +76,6 @@
               "image-key":          "ose_baremetal_cluster_api_controllers_rhel9",
               "image-ref":          "registry.stage.redhat.io/openshift4/ose-baremetal-cluster-api-controllers-rhel9:v4.22"
             },{
-              "image-key":          "postgresql_13",
-              "image-ref":          "registry.redhat.io/rhel9/postgresql-13:1-1766414400"
-            },{
               "image-key":          "postgresql_15",
               "image-ref":          "registry.redhat.io/rhel9/postgresql-15:1-1775009263"
             },{


### PR DESCRIPTION
## Summary
- Removes postgresql-13 image reference from `config/mce-manifest-gen-config.json`
- Postgresql 15 and 16 remain available

## Test plan
- [ ] Verify manifest generation succeeds
- [ ] Confirm postgresql-15 and postgresql-16 still referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)