### PR TITLE
Add stale issue and PR management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 13 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: '@${{ github.actor }} This issue has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        stale-pr-message: '@${{ github.actor }} This pull request has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'
+        close-pr-message: 'This pull request was closed because it has been stale for 7 days with no activity.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 5
+        days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: '@${{ github.actor }} This issue has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
-        stale-pr-message: '@${{ github.actor }} This pull request has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        stale-issue-message: 'This issue has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        stale-pr-message: 'This pull request has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
         close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'
         close-pr-message: 'This pull request was closed because it has been stale for 7 days with no activity.'
         stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow to automatically mark and close stale issues and pull requests based on inactivity.

## Changes Made

- Added `.github/workflows/stale.yml` workflow that:
  - Runs daily at 8am EST (1pm UTC)
  - Marks issues and PRs as stale after 5 days of inactivity
  - Closes stale issues and PRs after 7 additional days with no activity
  - Tags the author in the stale notification message
  - Applies `no-issue-activity` and `no-pr-activity` labels

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily maintenance for inactive issues and pull requests.
  * Items are labeled as stale after five days of inactivity and automatically closed after an additional seven days.
  * Added clear notifications to communicate stale and closure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->