### PR TITLE
chore: use timezone-aware schedules for snapshot workflows

### DIFF
--- a/.github/workflows/gen-latest-snapshot-mce-210.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-210.yaml
@@ -3,7 +3,8 @@ name: Gen Latest Dev Snapshot - MCE 2.10
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 17 * * 1,3,5'   # 1:00PM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 13 * * 1,3,5'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-211.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-211.yaml
@@ -3,8 +3,10 @@ name: Gen Latest Dev Snapshot - MCE 2.11
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 13 * * *'  # 9:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 18 * * *'  # 2:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 9 * * *'
+      timezone: "America/New_York"
+    - cron: '0 14 * * *'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-217.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-217.yaml
@@ -3,8 +3,10 @@ name: Gen Latest Dev Snapshot - MCE 2.17
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 14 * * *'  # 10:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 20 * * *'  # 4:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 10 * * *'
+      timezone: "America/New_York"
+    - cron: '0 16 * * *'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-26.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-26.yaml
@@ -3,7 +3,8 @@ name: Gen Latest Dev Snapshot - MCE 2.6
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 17 * * 4'  # 1:00PM ET Thursdays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 13 * * 4'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-28.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-28.yaml
@@ -3,7 +3,8 @@ name: Gen Latest Dev Snapshot - MCE 2.8
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 19 * * 2,4'   # 3:00PM ET Tuesdays and Thursdays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 15 * * 2,4'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-29.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-29.yaml
@@ -3,7 +3,8 @@ name: Gen Latest Dev Snapshot - MCE 2.9
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 19 * * 1,3,5'   # 3:00PM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 15 * * 1,3,5'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-50.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-50.yaml
@@ -3,9 +3,12 @@ name: Gen Latest Dev Snapshot - MCE 5.0
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 12 * * *'  # 8:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 16 * * *'  # 12:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 21 * * *'  # 5:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 8 * * *'
+      timezone: "America/New_York"
+    - cron: '0 12 * * *'
+      timezone: "America/New_York"
+    - cron: '0 17 * * *'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-mce-51.yaml
+++ b/.github/workflows/gen-latest-snapshot-mce-51.yaml
@@ -3,8 +3,10 @@ name: Gen Latest Dev Snapshot - MCE 5.1
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 15 * * *'  # 11:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 22 * * *'  # 6:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 11 * * *'
+      timezone: "America/New_York"
+    - cron: '0 18 * * *'
+      timezone: "America/New_York"
 
 jobs:
   snapshot:


### PR DESCRIPTION
# Description

Replace UTC cron offsets with local ET hours using GitHub Actions' native `timezone: "America/New_York"` field. DST transitions are handled automatically — no more UTC-4/UTC-5 ambiguity in comments or manual offset calculations.

## Related Issue

N/A

## Changes Made

All snapshot workflow cron expressions converted from UTC to local Eastern Time with `timezone: "America/New_York"` added to each schedule entry. No change to actual run times — builds fire at the same moments as before.

Example (MCE 5.0):
```yaml
# Before
- cron: '0 12 * * *'  # 8:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)

# After
- cron: '0 8 * * *'
  timezone: "America/New_York"
```

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

GitHub Actions has supported IANA timezone identifiers since March 2026. ACM operator-bundle has a matching PR.

## Reviewers

/cc @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.