### PR TITLE
fix: add git credential.helper to resolve intermittent clone failures

### DIFF
--- a/tools/run-script-from-tools-repo
+++ b/tools/run-script-from-tools-repo
@@ -115,6 +115,7 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
    # specifies the endodedd "token:<TOKEN_VALUE>" auth info.
 
    git remote add origin "https://github.com/$tools_repo"
+   git config credential.helper '!f() { echo "username=x-access-token"; echo "password='"$tools_repo_access_token"'"; }; f'
    basic_auth_creds="x-access-token:$tools_repo_access_token"
    basic_auth_encoded=$(echo -n "$basic_auth_creds" | base64)
    git config  "http.https://github.com/.extraheader" "Authorization: basic $basic_auth_encoded"


### PR DESCRIPTION
# Description

Add `git credential.helper` config to `tools/run-script-from-tools-repo` to fix intermittent `Failed sending HTTP request` errors when cloning `stolostron/release` during bundle generation workflows.

## Related Issue

- Same root cause as stolostron/release#888 and stolostron/release#889
- Failure rate has escalated from ~2% (early July) to ~22% (this week)

## Changes Made

Added `git config credential.helper` before the existing `http.extraheader` config in `tools/run-script-from-tools-repo`. This provides a fallback auth mechanism when the `http.extraheader` URL pattern matching fails on newer GitHub Actions runner images (`ubuntu24/20260525.161+`).

**Why both exist:** `http.extraheader` is kept for backward compatibility. When its URL pattern matches, auth works via header and `credential.helper` is never called. When the pattern doesn't match (the bug on newer runners), git gets a 401 and falls back to `credential.helper`. No conflict between the two.

**Root cause:** Newer git versions on updated runner images are stricter about URL pattern matching for `http.https://github.com/.extraheader`. URLs with trailing slashes after `.git/` no longer match, causing auth headers to not be applied.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Companion PR: https://github.com/stolostron/acm-operator-bundle/pull/4168

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication when fetching the tools repository by configuring the required Git credentials automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->