### PR TITLE
fix: remove duplicate Authorization header causing git fetch failures

### DIFF
--- a/tools/run-script-from-tools-repo
+++ b/tools/run-script-from-tools-repo
@@ -116,25 +116,15 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
 
    git remote add origin "https://github.com/$tools_repo"
    git config credential.helper '!f() { echo "username=x-access-token"; echo "password='"$tools_repo_access_token"'"; }; f'
-   basic_auth_creds="x-access-token:$tools_repo_access_token"
-   basic_auth_encoded=$(echo -n "$basic_auth_creds" | base64)
-   git config  "http.https://github.com/.extraheader" "Authorization: basic $basic_auth_encoded"
 
-   max_attempts=5
-   git_fetch_rc=1
-   backoff=5
-   for attempt in $(seq 1 $max_attempts); do
+   git fetch --depth 1 origin "$tools_repo_branch"
+   git_fetch_rc=$?
+   if [[ $git_fetch_rc -ne 0 ]]; then
+      echo "WARNING: git fetch failed with HTTP/2 (rc=$git_fetch_rc). Retrying with HTTP/1.1..."
+      git config http.version HTTP/1.1
       git fetch --depth 1 origin "$tools_repo_branch"
       git_fetch_rc=$?
-      if [[ $git_fetch_rc -eq 0 ]]; then
-         break
-      fi
-      if [[ $attempt -lt $max_attempts ]]; then
-         echo "WARNING: git fetch attempt $attempt of $max_attempts failed (rc=$git_fetch_rc). Retrying in ${backoff}s..."
-         sleep "$backoff"
-         backoff=$((backoff * 2))
-      fi
-   done
+   fi
 
    # In case we're run locally, be friendly and restore original Git SSH command
    if [[ -n "$save_git_ssh_cmd" ]]; then
@@ -143,7 +133,7 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
       git config --global --unset core.sshCommand
    fi
    if [[ $git_fetch_rc -ne 0 ]]; then
-      echo "ERROR: Could not fetch tools repo after $max_attempts attempts."
+      echo "ERROR: Could not fetch tools repo."
       exit 2
   fi
 


### PR DESCRIPTION
# Description

Fixes the root cause of `Failed sending HTTP request` errors when cloning the `stolostron/release` tools repo during bundle generation. Same fix as stolostron/acm-operator-bundle#4197.

## Related Issue

Same root cause as failures in acm-operator-bundle — duplicate Authorization headers from conflicting auth mechanisms.

## Changes Made

- Removed `http.extraheader` Authorization setup from `tools/run-script-from-tools-repo` — the `credential.helper` alone handles auth correctly
- Replaced 5-attempt retry loop with single HTTP/2 → HTTP/1.1 fallback since retries of the same broken request are ineffective

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Root cause diagnosed via `GIT_CURL_VERBOSE=1` in acm-operator-bundle. The duplicate auth headers caused HTTP/2 framing failures and HTTP/1.1 400 Bad Request responses from GitHub.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tools-repository fetching by using Git credential handling for authentication.
  * Added a fallback to HTTP/1.1 when the initial branch fetch fails.
  * Simplified fetch retries and improved error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->